### PR TITLE
fix: reject invalid peer DH public values in IKE_SA_INIT (#972)

### DIFF
--- a/pkg/ike/handler/handler.go
+++ b/pkg/ike/handler/handler.go
@@ -209,9 +209,14 @@ func HandleIKESAINIT(udpConn *net.UDPConn, tngfAddr, ueAddr *net.UDPAddr, messag
 		}
 
 		var localPublicValue []byte
+		var dhErr error
 
-		localPublicValue, sharedKeyData = CalculateDiffieHellmanMaterials(GenerateRandomNumber(),
+		localPublicValue, sharedKeyData, dhErr = CalculateDiffieHellmanMaterials(GenerateRandomNumber(),
 			keyExchange.KeyExchangeData, chosenDiffieHellmanGroup)
+		if dhErr != nil {
+			ikeLog.Warnf("Reject IKE_SA_INIT due to invalid peer Diffie-Hellman public value: %+v", dhErr)
+			return
+		}
 		responseIKEMessage.Payloads.BUildKeyExchange(chosenDiffieHellmanGroup, localPublicValue)
 	} else {
 		ikeLog.Error("The key exchange field is nil")

--- a/pkg/ike/handler/handler.go
+++ b/pkg/ike/handler/handler.go
@@ -215,6 +215,12 @@ func HandleIKESAINIT(udpConn *net.UDPConn, tngfAddr, ueAddr *net.UDPAddr, messag
 			keyExchange.KeyExchangeData, chosenDiffieHellmanGroup)
 		if dhErr != nil {
 			ikeLog.Warnf("Reject IKE_SA_INIT due to invalid peer Diffie-Hellman public value: %+v", dhErr)
+			responseIKEMessage.BuildIKEHeader(message.InitiatorSPI, message.ResponderSPI,
+				ike_message.IKE_SA_INIT, ike_message.ResponseBitCheck, message.MessageID)
+			responseIKEMessage.Payloads.Reset()
+			responseIKEMessage.Payloads.BuildNotification(
+				ike_message.TypeNone, ike_message.INVALID_SYNTAX, nil, nil)
+			SendIKEMessageToUE(udpConn, tngfAddr, ueAddr, responseIKEMessage)
 			return
 		}
 		responseIKEMessage.Payloads.BUildKeyExchange(chosenDiffieHellmanGroup, localPublicValue)

--- a/pkg/ike/handler/security.go
+++ b/pkg/ike/handler/security.go
@@ -89,7 +89,7 @@ const (
 
 func CalculateDiffieHellmanMaterials(secret *big.Int, peerPublicValue []byte,
 	diffieHellmanGroupNumber uint16,
-) (localPublicValue []byte, sharedKey []byte) {
+) (localPublicValue []byte, sharedKey []byte, err error) {
 	peerPublicValueBig := new(big.Int).SetBytes(peerPublicValue)
 	var generator, factor *big.Int
 	var ok bool
@@ -102,6 +102,7 @@ func CalculateDiffieHellmanMaterials(secret *big.Int, peerPublicValue []byte,
 			ikeLog.Errorf(
 				"Error occurs when setting big number \"factor\" in %d group",
 				diffieHellmanGroupNumber)
+			return nil, nil, errors.New("failed to initialize DH group factor")
 		}
 	case message.DH_2048_BIT_MODP:
 		generator = new(big.Int).SetUint64(Group14Generator)
@@ -110,10 +111,17 @@ func CalculateDiffieHellmanMaterials(secret *big.Int, peerPublicValue []byte,
 			ikeLog.Errorf(
 				"Error occurs when setting big number \"factor\" in %d group",
 				diffieHellmanGroupNumber)
+			return nil, nil, errors.New("failed to initialize DH group factor")
 		}
 	default:
 		ikeLog.Errorf("Unsupported Diffie-Hellman group: %d", diffieHellmanGroupNumber)
-		return nil, nil
+		return nil, nil, errors.New("unsupported Diffie-Hellman group")
+	}
+
+	one := big.NewInt(1)
+	pMinusOne := new(big.Int).Sub(factor, one)
+	if peerPublicValueBig.Cmp(one) <= 0 || peerPublicValueBig.Cmp(pMinusOne) >= 0 {
+		return nil, nil, errors.New("invalid DH public value")
 	}
 
 	localPublicValue = new(big.Int).Exp(generator, secret, factor).Bytes()
@@ -124,7 +132,7 @@ func CalculateDiffieHellmanMaterials(secret *big.Int, peerPublicValue []byte,
 	prependZero = make([]byte, len(factor.Bytes())-len(sharedKey))
 	sharedKey = append(prependZero, sharedKey...)
 
-	return localPublicValue, sharedKey
+	return localPublicValue, sharedKey, nil
 }
 
 // Pseudorandom Function

--- a/pkg/ike/handler/security.go
+++ b/pkg/ike/handler/security.go
@@ -90,6 +90,9 @@ const (
 func CalculateDiffieHellmanMaterials(secret *big.Int, peerPublicValue []byte,
 	diffieHellmanGroupNumber uint16,
 ) (localPublicValue []byte, sharedKey []byte, err error) {
+	if secret == nil {
+		return nil, nil, errors.New("failed to generate DH secret")
+	}
 	peerPublicValueBig := new(big.Int).SetBytes(peerPublicValue)
 	var generator, factor *big.Int
 	var ok bool


### PR DESCRIPTION
Closes https://github.com/free5gc/free5gc/issues/972

- Validate peer Diffie-Hellman public values during IKE SA setup.
- Reject out-of-range values before key derivation and return a clean negotiation failure.
- Fixes malformed-DH handling with a minimal, RFC 6989-aligned change.