### PR TITLE
fix: reject dual-null ESP Child SA proposals (#973)

### DIFF
--- a/pkg/ike/handler/handler.go
+++ b/pkg/ike/handler/handler.go
@@ -555,6 +555,7 @@ func HandleIKEAUTH(udpConn *net.UDPConn, tngfAddr, ueAddr *net.UDPAddr, message 
 				}
 			} // Optional
 			if encryptionAlgorithmTransform.TransformID == ike_message.ENCR_NULL && integrityAlgorithmTransform == nil {
+				ikeLog.Warn("Reject Child SA proposal: ENCR_NULL without integrity")
 				continue
 			}
 			if len(proposal.DiffieHellmanGroup) > 0 {

--- a/pkg/ike/handler/handler.go
+++ b/pkg/ike/handler/handler.go
@@ -554,6 +554,9 @@ func HandleIKEAUTH(udpConn *net.UDPConn, tngfAddr, ueAddr *net.UDPAddr, message 
 					continue
 				}
 			} // Optional
+			if encryptionAlgorithmTransform.TransformID == ike_message.ENCR_NULL && integrityAlgorithmTransform == nil {
+				continue
+			}
 			if len(proposal.DiffieHellmanGroup) > 0 {
 				for _, transform := range proposal.DiffieHellmanGroup {
 					if is_Kernel_Supported(ike_message.TypeDiffieHellmanGroup, transform.TransformID,


### PR DESCRIPTION
Closes https://github.com/free5gc/free5gc/issues/973

- Reject Child SA proposals that result in dual-null ESP (ENCR_NULL with no integrity).
- Fail proposal selection early instead of accepting an insecure combination.
- Prevents weak Child SA establishment and stays aligned with RFC 4303 security requirements.