### PR TITLE
fix: harden GRE unmarshal against short packet DoS

### DIFF
--- a/internal/gre/message.go
+++ b/internal/gre/message.go
@@ -50,7 +50,11 @@ func (p *GREPacket) Unmarshal(b []byte) error {
 
 	if p.GetKeyFlag() {
 		if len(b) < offset+GREHeaderKeyFieldLength {
-			return fmt.Errorf("gre packet with key flag too short: got %d, need at least %d", len(b), offset+GREHeaderKeyFieldLength)
+			return fmt.Errorf(
+				"gre packet with key flag too short: got %d, need at least %d",
+				len(b),
+				offset+GREHeaderKeyFieldLength,
+			)
 		}
 
 		p.key = binary.BigEndian.Uint32(b[offset : offset+GREHeaderKeyFieldLength])

--- a/internal/gre/message.go
+++ b/internal/gre/message.go
@@ -1,6 +1,9 @@
 package gre
 
-import "encoding/binary"
+import (
+	"encoding/binary"
+	"fmt"
+)
 
 // [TS 24.502] 9.3.3 GRE encapsulated user data packet
 const (
@@ -34,6 +37,10 @@ func (p *GREPacket) Marshal() []byte {
 }
 
 func (p *GREPacket) Unmarshal(b []byte) error {
+	if len(b) < 4 {
+		return fmt.Errorf("gre packet too short: got %d, need at least 4", len(b))
+	}
+
 	p.flags = b[0]
 	p.version = b[1]
 
@@ -42,6 +49,10 @@ func (p *GREPacket) Unmarshal(b []byte) error {
 	offset := 4
 
 	if p.GetKeyFlag() {
+		if len(b) < offset+GREHeaderKeyFieldLength {
+			return fmt.Errorf("gre packet with key flag too short: got %d, need at least %d", len(b), offset+GREHeaderKeyFieldLength)
+		}
+
 		p.key = binary.BigEndian.Uint32(b[offset : offset+GREHeaderKeyFieldLength])
 		offset += GREHeaderKeyFieldLength
 	}

--- a/internal/nwtup/service/service.go
+++ b/internal/nwtup/service/service.go
@@ -52,8 +52,8 @@ func Run(ctx context.Context) error {
 func listenAndServe(ipv4PacketConn *ipv4.PacketConn) {
 	defer func() {
 		if p := recover(); p != nil {
-			// Print stack for panic to log. Fatalf() will let program exit.
-			logger.NWtUPLog.Fatalf("panic: %v\n%s", p, string(debug.Stack()))
+			// Keep process alive on malformed user-plane packets.
+			logger.NWtUPLog.Errorf("panic: %v\n%s", p, string(debug.Stack()))
 		}
 
 		err := ipv4PacketConn.Close()
@@ -89,8 +89,8 @@ func listenAndServe(ipv4PacketConn *ipv4.PacketConn) {
 func forward(ueInnerIP string, ifIndex int, rawData []byte) {
 	defer func() {
 		if p := recover(); p != nil {
-			// Print stack for panic to log. Fatalf() will let program exit.
-			logger.NWtUPLog.Fatalf("panic: %v\n%s", p, string(debug.Stack()))
+			// Keep process alive on malformed user-plane packets.
+			logger.NWtUPLog.Errorf("panic: %v\n%s", p, string(debug.Stack()))
 		}
 	}()
 


### PR DESCRIPTION
Closes https://github.com/free5gc/free5gc/issues/988

- Validate GRE packet length before fixed-header and key-field reads in Unmarshal.
- Return parse errors for truncated GRE packets instead of panicking on short input.
- Change NWtUP panic recovery from fatal exit to non-fatal error logging to prevent process-wide DoS.