### PR TITLE
fix: validate CalledStationId length to prevent remote DoS panic

### DIFF
--- a/pkg/radius/handler/handler.go
+++ b/pkg/radius/handler/handler.go
@@ -58,6 +58,10 @@ func HandleRadiusAccessRequest(udpConn *net.UDPConn, tngfAddr, ueAddr *net.UDPAd
 			eapMessage = radiusPayload.Val
 		case radius_message.TypeCalledStationId:
 			calledStationId = string(radiusPayload.Val)
+			if len(calledStationId) < 17 {
+				radiusLog.Errorln("CalledStationId too short:", len(calledStationId))
+				continue
+			}
 			calledStationId = strings.ReplaceAll(calledStationId[:17], "-", "")
 			tnapId, err = strconv.ParseUint(calledStationId, 16, 64)
 			if err != nil {


### PR DESCRIPTION
## Security Fix

Fixes free5gc/free5gc#1001

### Vulnerability

A remote, unauthenticated attacker can crash the entire TNGF process by sending a single 26-byte RADIUS Access-Request with a `Called-Station-Id` attribute shorter than 17 bytes.

```go
// handler.go:61 — panics when len(calledStationId) < 17
calledStationId = strings.ReplaceAll(calledStationId[:17], "-", "")
```

**No authentication required.** A single UDP packet to port 1812 causes an immediate panic → `os.Exit(1)`.

### Fix

Add a length check before slicing:

```go
if len(calledStationId) < 17 {
    radiusLog.Errorln("CalledStationId too short:", len(calledStationId))
    continue
}
```