### PR TITLE
fix: validate ENCR_NULL padding length to prevent remote DoS panic

### DIFF
--- a/pkg/ike/handler/security.go
+++ b/pkg/ike/handler/security.go
@@ -11,6 +11,7 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"hash"
 	"io"
 	"math/big"
@@ -291,6 +292,9 @@ func DecryptMessage(key []byte, cipherText []byte, algorithmType uint16) ([]byte
 		}
 
 		padding := int(cipherText[len(cipherText)-1]) + 1
+		if padding > len(cipherText) {
+			return nil, fmt.Errorf("ENCR_NULL: invalid padding length %d exceeds data length %d", padding, len(cipherText))
+		}
 		plainText := cipherText[:len(cipherText)-padding]
 
 		return plainText, nil


### PR DESCRIPTION
## Security Fix

Fixes free5gc/free5gc#999

### Vulnerability

`DecryptMessage()` ENCR_NULL code path reads the last byte as padding length without validation:

```go
padding := int(cipherText[len(cipherText)-1]) + 1   // attacker controls this
plainText := cipherText[:len(cipherText)-padding]    // PANIC: negative index
```

With ENCR_NULL, no encryption is applied — the attacker directly controls the bytes. A single 48-byte crafted packet after IKE_SA_INIT crashes the entire TNGF process.

### Fix

Validate padding before slicing:

```go
if padding > len(cipherText) {
    return nil, fmt.Errorf("ENCR_NULL: invalid padding length %d exceeds data length %d", padding, len(cipherText))
}
```