### PR TITLE
fix: validate padding in DecryptMessage (AES-CBC + ENCR_NULL) to prevent remote DoS

### DIFF
--- a/pkg/ike/handler/security.go
+++ b/pkg/ike/handler/security.go
@@ -11,6 +11,7 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"hash"
 	"io"
 	"math/big"
@@ -279,6 +280,9 @@ func DecryptMessage(key []byte, cipherText []byte, algorithmType uint16) ([]byte
 		ikeLog.Tracef("Decrypted content:\n%s", hex.Dump(plainText))
 
 		padding := int(plainText[len(plainText)-1]) + 1
+		if padding > len(plainText) {
+			return nil, fmt.Errorf("ENCR_AES_CBC: invalid padding length %d exceeds plaintext length %d", padding, len(plainText))
+		}
 		plainText = plainText[:len(plainText)-padding]
 
 		ikeLog.Tracef("Decrypted content with out padding:\n%s", hex.Dump(plainText))
@@ -291,6 +295,9 @@ func DecryptMessage(key []byte, cipherText []byte, algorithmType uint16) ([]byte
 		}
 
 		padding := int(cipherText[len(cipherText)-1]) + 1
+		if padding > len(cipherText) {
+			return nil, fmt.Errorf("ENCR_NULL: invalid padding length %d exceeds data length %d", padding, len(cipherText))
+		}
 		plainText := cipherText[:len(cipherText)-padding]
 
 		return plainText, nil

--- a/pkg/ike/handler/security.go
+++ b/pkg/ike/handler/security.go
@@ -281,7 +281,9 @@ func DecryptMessage(key []byte, cipherText []byte, algorithmType uint16) ([]byte
 
 		padding := int(plainText[len(plainText)-1]) + 1
 		if padding > len(plainText) {
-			return nil, fmt.Errorf("ENCR_AES_CBC: invalid padding length %d exceeds plaintext length %d", padding, len(plainText))
+			return nil, fmt.Errorf(
+				"ENCR_AES_CBC: invalid padding length %d exceeds plaintext length %d", padding, len(plainText),
+			)
 		}
 		plainText = plainText[:len(plainText)-padding]
 


### PR DESCRIPTION
## Security Fix

Fixes free5gc/free5gc#998, free5gc/free5gc#999

### Vulnerability

Both `ENCR_AES_CBC` and `ENCR_NULL` code paths in `DecryptMessage()` read the last byte as padding length without validation:

**ENCR_AES_CBC (line 281-282):**
```go
padding := int(plainText[len(plainText)-1]) + 1
plainText = plainText[:len(plainText)-padding]  // PANIC
```

**ENCR_NULL (line 293-294):**
```go
padding := int(cipherText[len(cipherText)-1]) + 1
plainText := cipherText[:len(cipherText)-padding]  // PANIC
```

Both paths crash the entire TNGF process via `recover() → Fatalf → os.Exit(1)`.

### Fix

Add bounds validation before slicing in both code paths.