### PR TITLE
fix: handle empty proposals and invalid SPI length in CREATE_CHILD_SA (#990)

### DIFF
--- a/pkg/ike/handler/handler.go
+++ b/pkg/ike/handler/handler.go
@@ -1136,6 +1136,16 @@ func HandleCREATECHILDSA(udpConn *net.UDPConn, tngfAddr, ueAddr *net.UDPAddr, me
 		return
 	}
 
+	if len(securityAssociation.Proposals) == 0 {
+		ikeLog.Warn("No proposal in CREATE_CHILD_SA response")
+		return
+	}
+
+	if len(securityAssociation.Proposals[0].SPI) < 4 {
+		ikeLog.Warnf("Invalid SPI length in CREATE_CHILD_SA response proposal: %d", len(securityAssociation.Proposals[0].SPI))
+		return
+	}
+
 	if trafficSelectorInitiator == nil {
 		ikeLog.Error("The traffic selector initiator field is nil")
 		return


### PR DESCRIPTION
Closes https://github.com/free5gc/free5gc/issues/990

- Prevents CREATE_CHILD_SA panic by validating proposal presence and SPI length before indexing.
- Returns safely on malformed inputs instead of dereferencing empty arrays.