### PR TITLE
fix: set default XFRM replay window in ApplyXFRMRule function (#993)

### DIFF
--- a/pkg/ike/xfrm/xfrm.go
+++ b/pkg/ike/xfrm/xfrm.go
@@ -16,6 +16,8 @@ import (
 // Log
 var ikeLog *logrus.Entry
 
+const defaultXFRMReplayWindow = 32
+
 func init() {
 	ikeLog = logger.IKELog
 }
@@ -103,6 +105,7 @@ func ApplyXFRMRule(tngf_is_initiator bool, xfrmiId uint32,
 	xfrmState.Auth = xfrmIntegrityAlgorithm
 	xfrmState.Crypt = xfrmEncryptionAlgorithm
 	xfrmState.ESN = childSecurityAssociation.ESN
+	xfrmState.ReplayWindow = defaultXFRMReplayWindow
 
 	if childSecurityAssociation.EnableEncapsulate {
 		xfrmState.Encap = &netlink.XfrmStateEncap{


### PR DESCRIPTION
Closes https://github.com/free5gc/free5gc/issues/993

Enables ESP anti-replay protection by setting a replay window in XFRM state creation.
Keeps existing SA setup flow unchanged while hardening packet replay handling.