### PR TITLE
fix: add Message ID validation for IKE CREATE_CHILD_SA and INFORMATION (#995)

### DIFF
--- a/internal/nwtup/service/service.go
+++ b/internal/nwtup/service/service.go
@@ -104,15 +104,13 @@ func forward(ueInnerIP string, ifIndex int, rawData []byte) {
 
 	var pduSession *tngf_context.PDUSession
 
-	ue.ChildSAMu.RLock()
-	for _, childSA := range ue.TNGFChildSecurityAssociation {
+	ue.RangeChildSA(func(_ uint32, childSA *tngf_context.ChildSecurityAssociation) {
 		// Check which child SA the packet come from with interface index,
 		// and find the corresponding PDU session
 		if childSA.XfrmIface != nil && childSA.XfrmIface.Attrs().Index == ifIndex {
 			pduSession = ue.PduSessionList[childSA.PDUSessionIds[0]]
 		}
-	}
-	ue.ChildSAMu.RUnlock()
+	})
 
 	if pduSession == nil {
 		nwtupLog.Error("This UE doesn't have any available PDU session")

--- a/pkg/context/ue.go
+++ b/pkg/context/ue.go
@@ -147,6 +147,9 @@ type IKESecurityAssociation struct {
 	InitiatorMessageID uint32
 	ResponderMessageID uint32
 
+	// Message ID validation state
+	PeerRequestMessageID uint32
+
 	// Transforms for IKE SA
 	EncryptionAlgorithm    *ike_message.Transform
 	PseudorandomFunction   *ike_message.Transform

--- a/pkg/context/ue.go
+++ b/pkg/context/ue.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"sync"
 
 	"github.com/vishvananda/netlink"
 	gtpv1 "github.com/wmnsk/go-gtp/gtpv1"
@@ -76,6 +77,7 @@ type TNGFUe struct {
 	// Exchange Message ID(including a SPI) and ChildSA(including a SPI)
 	// Mapping of Message ID of exchange in IKE and Child SA when creating new child SA
 	TemporaryExchangeMsgIDChildSAMapping map[uint32]*ChildSecurityAssociation // Message ID as a key
+	TemporaryExchangeMsgIDChildSAMu      sync.Mutex
 
 	/* NAS IKE Connection */
 	IKEConnection *UDPSocketInfo
@@ -149,6 +151,7 @@ type IKESecurityAssociation struct {
 
 	// Message ID validation state
 	PeerRequestMessageID uint32
+	MessageIDMu          sync.Mutex
 
 	// Transforms for IKE SA
 	EncryptionAlgorithm    *ike_message.Transform
@@ -285,6 +288,9 @@ func (ue *TNGFUe) CreatePDUSession(pduSessionID int64, snssai ngapType.SNSSAI) (
 // When TNGF send CREATE_CHILD_SA request to N3UE, the inbound SPI of childSA will be only stored first until
 // receive response and call CompleteChildSAWithProposal to fill the all data of childSA
 func (ue *TNGFUe) CreateHalfChildSA(msgID, inboundSPI uint32, pduSessionID int64) {
+	ue.TemporaryExchangeMsgIDChildSAMu.Lock()
+	defer ue.TemporaryExchangeMsgIDChildSAMu.Unlock()
+
 	childSA := new(ChildSecurityAssociation)
 	childSA.InboundSPI = inboundSPI
 	childSA.PDUSessionIds = append(childSA.PDUSessionIds, pduSessionID)
@@ -294,9 +300,20 @@ func (ue *TNGFUe) CreateHalfChildSA(msgID, inboundSPI uint32, pduSessionID int64
 	ue.TemporaryExchangeMsgIDChildSAMapping[msgID] = childSA
 }
 
+func (ue *TNGFUe) HasHalfChildSA(msgID uint32) bool {
+	ue.TemporaryExchangeMsgIDChildSAMu.Lock()
+	defer ue.TemporaryExchangeMsgIDChildSAMu.Unlock()
+
+	_, ok := ue.TemporaryExchangeMsgIDChildSAMapping[msgID]
+	return ok
+}
+
 func (ue *TNGFUe) CompleteChildSA(msgID uint32, outboundSPI uint32,
 	chosenSecurityAssociation *ike_message.SecurityAssociation,
 ) (*ChildSecurityAssociation, error) {
+	ue.TemporaryExchangeMsgIDChildSAMu.Lock()
+	defer ue.TemporaryExchangeMsgIDChildSAMu.Unlock()
+
 	childSA, ok := ue.TemporaryExchangeMsgIDChildSAMapping[msgID]
 
 	if !ok {

--- a/pkg/context/ue.go
+++ b/pkg/context/ue.go
@@ -383,13 +383,31 @@ func (ue *TNGFUe) CompleteChildSA(msgID uint32, outboundSPI uint32,
 	}
 
 	// Record to UE context with inbound SPI as key
-	ue.ChildSAMu.Lock()
-	ue.TNGFChildSecurityAssociation[childSA.InboundSPI] = childSA
-	ue.ChildSAMu.Unlock()
+	ue.StoreChildSA(childSA.InboundSPI, childSA)
 	// Record to TNGF context with inbound SPI as key
 	tngfContext.ChildSA.Store(childSA.InboundSPI, childSA)
 
 	return childSA, nil
+}
+
+func (ue *TNGFUe) StoreChildSA(inboundSPI uint32, childSA *ChildSecurityAssociation) {
+	ue.ChildSAMu.Lock()
+	defer ue.ChildSAMu.Unlock()
+	ue.TNGFChildSecurityAssociation[inboundSPI] = childSA
+}
+
+func (ue *TNGFUe) DeleteChildSA(inboundSPI uint32) {
+	ue.ChildSAMu.Lock()
+	defer ue.ChildSAMu.Unlock()
+	delete(ue.TNGFChildSecurityAssociation, inboundSPI)
+}
+
+func (ue *TNGFUe) RangeChildSA(fn func(uint32, *ChildSecurityAssociation)) {
+	ue.ChildSAMu.RLock()
+	defer ue.ChildSAMu.RUnlock()
+	for spi, childSA := range ue.TNGFChildSecurityAssociation {
+		fn(spi, childSA)
+	}
 }
 
 func (ue *TNGFUe) AttachAMF(sctpAddr string) bool {

--- a/pkg/context/ue.go
+++ b/pkg/context/ue.go
@@ -153,6 +153,9 @@ type IKESecurityAssociation struct {
 	InitiatorMessageID uint32
 	ResponderMessageID uint32
 
+	// Message ID validation state
+	PeerRequestMessageID uint32
+
 	// Transforms for IKE SA
 	EncryptionAlgorithm    *ike_message.Transform
 	PseudorandomFunction   *ike_message.Transform

--- a/pkg/context/ue.go
+++ b/pkg/context/ue.go
@@ -80,6 +80,7 @@ type TNGFUe struct {
 	// Exchange Message ID(including a SPI) and ChildSA(including a SPI)
 	// Mapping of Message ID of exchange in IKE and Child SA when creating new child SA
 	TemporaryExchangeMsgIDChildSAMapping map[uint32]*ChildSecurityAssociation // Message ID as a key
+	TemporaryExchangeMsgIDChildSAMu      sync.Mutex
 
 	/* NAS IKE Connection */
 	IKEConnection *UDPSocketInfo
@@ -155,6 +156,7 @@ type IKESecurityAssociation struct {
 
 	// Message ID validation state
 	PeerRequestMessageID uint32
+	MessageIDMu          sync.Mutex
 
 	// Transforms for IKE SA
 	EncryptionAlgorithm    *ike_message.Transform
@@ -291,6 +293,9 @@ func (ue *TNGFUe) CreatePDUSession(pduSessionID int64, snssai ngapType.SNSSAI) (
 // When TNGF send CREATE_CHILD_SA request to N3UE, the inbound SPI of childSA will be only stored first until
 // receive response and call CompleteChildSAWithProposal to fill the all data of childSA
 func (ue *TNGFUe) CreateHalfChildSA(msgID, inboundSPI uint32, pduSessionID int64) {
+	ue.TemporaryExchangeMsgIDChildSAMu.Lock()
+	defer ue.TemporaryExchangeMsgIDChildSAMu.Unlock()
+
 	childSA := new(ChildSecurityAssociation)
 	childSA.InboundSPI = inboundSPI
 	childSA.PDUSessionIds = append(childSA.PDUSessionIds, pduSessionID)
@@ -300,9 +305,20 @@ func (ue *TNGFUe) CreateHalfChildSA(msgID, inboundSPI uint32, pduSessionID int64
 	ue.TemporaryExchangeMsgIDChildSAMapping[msgID] = childSA
 }
 
+func (ue *TNGFUe) HasHalfChildSA(msgID uint32) bool {
+	ue.TemporaryExchangeMsgIDChildSAMu.Lock()
+	defer ue.TemporaryExchangeMsgIDChildSAMu.Unlock()
+
+	_, ok := ue.TemporaryExchangeMsgIDChildSAMapping[msgID]
+	return ok
+}
+
 func (ue *TNGFUe) CompleteChildSA(msgID uint32, outboundSPI uint32,
 	chosenSecurityAssociation *ike_message.SecurityAssociation,
 ) (*ChildSecurityAssociation, error) {
+	ue.TemporaryExchangeMsgIDChildSAMu.Lock()
+	defer ue.TemporaryExchangeMsgIDChildSAMu.Unlock()
+
 	childSA, ok := ue.TemporaryExchangeMsgIDChildSAMapping[msgID]
 
 	if !ok {

--- a/pkg/context/ue.go
+++ b/pkg/context/ue.go
@@ -20,6 +20,8 @@ const (
 	AmfUeNgapIdUnspecified int64 = 0xffffffffff
 )
 
+const pendingChildSALifetime = 5 * time.Minute
+
 type RadiusSession struct {
 	CallingStationID string
 	State            uint8
@@ -79,8 +81,9 @@ type TNGFUe struct {
 	/* Temporary Mapping of two SPIs */
 	// Exchange Message ID(including a SPI) and ChildSA(including a SPI)
 	// Mapping of Message ID of exchange in IKE and Child SA when creating new child SA
-	TemporaryExchangeMsgIDChildSAMapping map[uint32]*ChildSecurityAssociation // Message ID as a key
-	TemporaryExchangeMsgIDChildSAMu      sync.Mutex
+	TemporaryExchangeMsgIDChildSAMapping   map[uint32]*ChildSecurityAssociation // Message ID as a key
+	TemporaryExchangeMsgIDChildSAExpiresAt map[uint32]time.Time
+	TemporaryExchangeMsgIDChildSAMu        sync.Mutex
 
 	/* NAS IKE Connection */
 	IKEConnection *UDPSocketInfo
@@ -254,6 +257,7 @@ func (ue *TNGFUe) init(ranUeNgapId int64) {
 	ue.PduSessionList = make(map[int64]*PDUSession)
 	ue.TNGFChildSecurityAssociation = make(map[uint32]*ChildSecurityAssociation)
 	ue.TemporaryExchangeMsgIDChildSAMapping = make(map[uint32]*ChildSecurityAssociation)
+	ue.TemporaryExchangeMsgIDChildSAExpiresAt = make(map[uint32]time.Time)
 }
 
 func (ue *TNGFUe) Remove() {
@@ -295,6 +299,13 @@ func (ue *TNGFUe) CreatePDUSession(pduSessionID int64, snssai ngapType.SNSSAI) (
 func (ue *TNGFUe) CreateHalfChildSA(msgID, inboundSPI uint32, pduSessionID int64) {
 	ue.TemporaryExchangeMsgIDChildSAMu.Lock()
 	defer ue.TemporaryExchangeMsgIDChildSAMu.Unlock()
+	if ue.TemporaryExchangeMsgIDChildSAMapping == nil {
+		ue.TemporaryExchangeMsgIDChildSAMapping = make(map[uint32]*ChildSecurityAssociation)
+	}
+	if ue.TemporaryExchangeMsgIDChildSAExpiresAt == nil {
+		ue.TemporaryExchangeMsgIDChildSAExpiresAt = make(map[uint32]time.Time)
+	}
+	ue.cleanupExpiredHalfChildSA(time.Now())
 
 	childSA := new(ChildSecurityAssociation)
 	childSA.InboundSPI = inboundSPI
@@ -303,14 +314,25 @@ func (ue *TNGFUe) CreateHalfChildSA(msgID, inboundSPI uint32, pduSessionID int64
 	childSA.ThisUE = ue
 	// Map Exchange Message ID and Child SA data until get paired response
 	ue.TemporaryExchangeMsgIDChildSAMapping[msgID] = childSA
+	ue.TemporaryExchangeMsgIDChildSAExpiresAt[msgID] = time.Now().Add(pendingChildSALifetime)
 }
 
 func (ue *TNGFUe) HasHalfChildSA(msgID uint32) bool {
 	ue.TemporaryExchangeMsgIDChildSAMu.Lock()
 	defer ue.TemporaryExchangeMsgIDChildSAMu.Unlock()
+	ue.cleanupExpiredHalfChildSA(time.Now())
 
 	_, ok := ue.TemporaryExchangeMsgIDChildSAMapping[msgID]
 	return ok
+}
+
+func (ue *TNGFUe) cleanupExpiredHalfChildSA(now time.Time) {
+	for msgID, expiresAt := range ue.TemporaryExchangeMsgIDChildSAExpiresAt {
+		if now.After(expiresAt) {
+			delete(ue.TemporaryExchangeMsgIDChildSAMapping, msgID)
+			delete(ue.TemporaryExchangeMsgIDChildSAExpiresAt, msgID)
+		}
+	}
 }
 
 func (ue *TNGFUe) CompleteChildSA(msgID uint32, outboundSPI uint32,
@@ -325,8 +347,16 @@ func (ue *TNGFUe) CompleteChildSA(msgID uint32, outboundSPI uint32,
 		return nil, fmt.Errorf("there's not a half child SA created by the exchange with message ID %d", msgID)
 	}
 
+	expiresAt, hasExpiry := ue.TemporaryExchangeMsgIDChildSAExpiresAt[msgID]
+	if hasExpiry && time.Now().After(expiresAt) {
+		delete(ue.TemporaryExchangeMsgIDChildSAMapping, msgID)
+		delete(ue.TemporaryExchangeMsgIDChildSAExpiresAt, msgID)
+		return nil, fmt.Errorf("half child SA for message ID %d expired", msgID)
+	}
+
 	// Remove mapping of exchange msg ID and child SA
 	delete(ue.TemporaryExchangeMsgIDChildSAMapping, msgID)
+	delete(ue.TemporaryExchangeMsgIDChildSAExpiresAt, msgID)
 
 	if chosenSecurityAssociation == nil {
 		return nil, errors.New("chosenSecurityAssociation is nil")

--- a/pkg/ike/dispatcher.go
+++ b/pkg/ike/dispatcher.go
@@ -7,6 +7,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/free5gc/tngf/internal/logger"
+	"github.com/free5gc/tngf/pkg/context"
 	"github.com/free5gc/tngf/pkg/ike/handler"
 	ike_message "github.com/free5gc/tngf/pkg/ike/message"
 )
@@ -15,6 +16,57 @@ var ikeLog *logrus.Entry
 
 func init() {
 	ikeLog = logger.IKELog
+}
+
+func isResponseMessage(ikeMessage *ike_message.IKEMessage) bool {
+	return (ikeMessage.Flags & ike_message.ResponseBitCheck) != 0
+}
+
+func validateAndTrackMessageID(ikeMessage *ike_message.IKEMessage) bool {
+	if ikeMessage == nil || ikeMessage.ExchangeType == ike_message.IKE_SA_INIT {
+		return true
+	}
+
+	if isResponseMessage(ikeMessage) {
+		if ikeMessage.ExchangeType != ike_message.CREATE_CHILD_SA {
+			return true
+		}
+
+		ikeSecurityAssociation, ok := context.TNGFSelf().IKESALoad(ikeMessage.ResponderSPI)
+		if !ok {
+			// Let handlers process unknown SPI and emit their existing INVALID_IKE_SPI behavior.
+			return true
+		}
+
+		if ikeSecurityAssociation.ThisUE == nil {
+			ikeLog.Warn("Unexpected CREATE_CHILD_SA response: UE context is nil")
+			return false
+		}
+
+		if _, exists := ikeSecurityAssociation.ThisUE.TemporaryExchangeMsgIDChildSAMapping[ikeMessage.MessageID]; !exists {
+			ikeLog.Warnf(
+				"Unexpected CREATE_CHILD_SA response MessageID: got %d with no pending exchange",
+				ikeMessage.MessageID,
+			)
+			return false
+		}
+
+		return true
+	}
+
+	ikeSecurityAssociation, ok := context.TNGFSelf().IKESALoad(ikeMessage.ResponderSPI)
+	if !ok {
+		// Let handlers process unknown SPI and emit their existing INVALID_IKE_SPI behavior.
+		return true
+	}
+
+	expectedMessageID := ikeSecurityAssociation.PeerRequestMessageID + 1
+	if ikeMessage.MessageID != expectedMessageID {
+		ikeLog.Warnf("Unexpected request MessageID: got %d, expected %d", ikeMessage.MessageID, expectedMessageID)
+		return false
+	}
+	ikeSecurityAssociation.PeerRequestMessageID = ikeMessage.MessageID
+	return true
 }
 
 func Dispatch(udpConn *net.UDPConn, localAddr, remoteAddr *net.UDPAddr, msg []byte) {
@@ -47,6 +99,10 @@ func Dispatch(udpConn *net.UDPConn, localAddr, remoteAddr *net.UDPAddr, msg []by
 		return
 	}
 
+	if !validateAndTrackMessageID(ikeMessage) {
+		return
+	}
+
 	switch ikeMessage.ExchangeType {
 	case ike_message.IKE_SA_INIT:
 		handler.HandleIKESAINIT(udpConn, localAddr, remoteAddr, ikeMessage)
@@ -54,6 +110,8 @@ func Dispatch(udpConn *net.UDPConn, localAddr, remoteAddr *net.UDPAddr, msg []by
 		handler.HandleIKEAUTH(udpConn, localAddr, remoteAddr, ikeMessage)
 	case ike_message.CREATE_CHILD_SA:
 		handler.HandleCREATECHILDSA(udpConn, localAddr, remoteAddr, ikeMessage)
+	case ike_message.INFORMATIONAL:
+		handler.HandleInformational(udpConn, localAddr, remoteAddr, ikeMessage)
 	default:
 		ikeLog.Warnf("Unimplemented IKE message type, exchange type: %d", ikeMessage.ExchangeType)
 	}

--- a/pkg/ike/dispatcher.go
+++ b/pkg/ike/dispatcher.go
@@ -22,6 +22,14 @@ func isResponseMessage(ikeMessage *ike_message.IKEMessage) bool {
 	return (ikeMessage.Flags & ike_message.ResponseBitCheck) != 0
 }
 
+type messageIDValidationResult int
+
+const (
+	messageIDValidationProcess messageIDValidationResult = iota
+	messageIDValidationDrop
+	messageIDValidationRetransmit
+)
+
 func loadIKESAForMessageIDValidation(ikeMessage *ike_message.IKEMessage) (*context.IKESecurityAssociation, bool) {
 	if ikeSecurityAssociation, ok := context.TNGFSelf().IKESALoad(ikeMessage.ResponderSPI); ok {
 		return ikeSecurityAssociation, true
@@ -34,25 +42,25 @@ func loadIKESAForMessageIDValidation(ikeMessage *ike_message.IKEMessage) (*conte
 	return context.TNGFSelf().IKESALoad(ikeMessage.InitiatorSPI)
 }
 
-func validateAndTrackMessageID(ikeMessage *ike_message.IKEMessage) bool {
+func validateAndTrackMessageID(ikeMessage *ike_message.IKEMessage) messageIDValidationResult {
 	if ikeMessage == nil || ikeMessage.ExchangeType == ike_message.IKE_SA_INIT {
-		return true
+		return messageIDValidationProcess
 	}
 
 	if isResponseMessage(ikeMessage) {
 		if ikeMessage.ExchangeType != ike_message.CREATE_CHILD_SA {
-			return true
+			return messageIDValidationProcess
 		}
 
 		ikeSecurityAssociation, ok := loadIKESAForMessageIDValidation(ikeMessage)
 		if !ok {
 			// Let handlers process unknown SPI and emit their existing INVALID_IKE_SPI behavior.
-			return true
+			return messageIDValidationProcess
 		}
 
 		if ikeSecurityAssociation.ThisUE == nil {
 			ikeLog.Warn("Unexpected CREATE_CHILD_SA response: UE context is nil")
-			return false
+			return messageIDValidationDrop
 		}
 
 		if !ikeSecurityAssociation.ThisUE.HasHalfChildSA(ikeMessage.MessageID) {
@@ -60,33 +68,34 @@ func validateAndTrackMessageID(ikeMessage *ike_message.IKEMessage) bool {
 				"Unexpected CREATE_CHILD_SA response MessageID: got %d with no pending exchange",
 				ikeMessage.MessageID,
 			)
-			return false
+			return messageIDValidationDrop
 		}
 
-		return true
+		return messageIDValidationProcess
 	}
 
 	ikeSecurityAssociation, ok := loadIKESAForMessageIDValidation(ikeMessage)
 	if !ok {
 		// Let handlers process unknown SPI and emit their existing INVALID_IKE_SPI behavior.
-		return true
+		return messageIDValidationProcess
 	}
 
 	ikeSecurityAssociation.MessageIDMu.Lock()
 	defer ikeSecurityAssociation.MessageIDMu.Unlock()
 
 	if ikeMessage.MessageID == ikeSecurityAssociation.PeerRequestMessageID {
-		ikeLog.Debugf("Accepting retransmitted request MessageID: %d", ikeMessage.MessageID)
-		return true
+		ikeLog.Debugf("Retransmitting response for request MessageID: %d", ikeMessage.MessageID)
+		return messageIDValidationRetransmit
 	}
 
 	expectedMessageID := ikeSecurityAssociation.PeerRequestMessageID + 1
 	if ikeMessage.MessageID != expectedMessageID {
 		ikeLog.Warnf("Unexpected request MessageID: got %d, expected %d", ikeMessage.MessageID, expectedMessageID)
-		return false
+		return messageIDValidationDrop
 	}
 	ikeSecurityAssociation.PeerRequestMessageID = ikeMessage.MessageID
-	return true
+	handler.ForgetCachedIKEResponsesBefore(ikeMessage.ResponderSPI, ikeMessage.MessageID)
+	return messageIDValidationProcess
 }
 
 func Dispatch(udpConn *net.UDPConn, localAddr, remoteAddr *net.UDPAddr, msg []byte) {
@@ -119,7 +128,15 @@ func Dispatch(udpConn *net.UDPConn, localAddr, remoteAddr *net.UDPAddr, msg []by
 		return
 	}
 
-	if !validateAndTrackMessageID(ikeMessage) {
+	switch validateAndTrackMessageID(ikeMessage) {
+	case messageIDValidationDrop:
+		return
+	case messageIDValidationRetransmit:
+		if !handler.RetransmitCachedIKEMessageToUE(
+			udpConn, localAddr, remoteAddr, ikeMessage.ResponderSPI, ikeMessage.MessageID,
+		) {
+			ikeLog.Warnf("No cached response for retransmitted request MessageID: %d", ikeMessage.MessageID)
+		}
 		return
 	}
 

--- a/pkg/ike/dispatcher.go
+++ b/pkg/ike/dispatcher.go
@@ -22,6 +22,18 @@ func isResponseMessage(ikeMessage *ike_message.IKEMessage) bool {
 	return (ikeMessage.Flags & ike_message.ResponseBitCheck) != 0
 }
 
+func loadIKESAForMessageIDValidation(ikeMessage *ike_message.IKEMessage) (*context.IKESecurityAssociation, bool) {
+	if ikeSecurityAssociation, ok := context.TNGFSelf().IKESALoad(ikeMessage.ResponderSPI); ok {
+		return ikeSecurityAssociation, true
+	}
+
+	// TNGF-initiated exchanges should normally retain the original IKE SA SPI
+	// ordering, but some existing CREATE_CHILD_SA paths build outbound headers
+	// with the local SPI in InitiatorSPI. Check both positions so response
+	// validation is not silently bypassed.
+	return context.TNGFSelf().IKESALoad(ikeMessage.InitiatorSPI)
+}
+
 func validateAndTrackMessageID(ikeMessage *ike_message.IKEMessage) bool {
 	if ikeMessage == nil || ikeMessage.ExchangeType == ike_message.IKE_SA_INIT {
 		return true
@@ -32,7 +44,7 @@ func validateAndTrackMessageID(ikeMessage *ike_message.IKEMessage) bool {
 			return true
 		}
 
-		ikeSecurityAssociation, ok := context.TNGFSelf().IKESALoad(ikeMessage.ResponderSPI)
+		ikeSecurityAssociation, ok := loadIKESAForMessageIDValidation(ikeMessage)
 		if !ok {
 			// Let handlers process unknown SPI and emit their existing INVALID_IKE_SPI behavior.
 			return true
@@ -54,7 +66,7 @@ func validateAndTrackMessageID(ikeMessage *ike_message.IKEMessage) bool {
 		return true
 	}
 
-	ikeSecurityAssociation, ok := context.TNGFSelf().IKESALoad(ikeMessage.ResponderSPI)
+	ikeSecurityAssociation, ok := loadIKESAForMessageIDValidation(ikeMessage)
 	if !ok {
 		// Let handlers process unknown SPI and emit their existing INVALID_IKE_SPI behavior.
 		return true

--- a/pkg/ike/dispatcher.go
+++ b/pkg/ike/dispatcher.go
@@ -55,7 +55,7 @@ func validateAndTrackMessageID(ikeMessage *ike_message.IKEMessage) bool {
 			return false
 		}
 
-		if _, exists := ikeSecurityAssociation.ThisUE.TemporaryExchangeMsgIDChildSAMapping[ikeMessage.MessageID]; !exists {
+		if !ikeSecurityAssociation.ThisUE.HasHalfChildSA(ikeMessage.MessageID) {
 			ikeLog.Warnf(
 				"Unexpected CREATE_CHILD_SA response MessageID: got %d with no pending exchange",
 				ikeMessage.MessageID,
@@ -69,6 +69,14 @@ func validateAndTrackMessageID(ikeMessage *ike_message.IKEMessage) bool {
 	ikeSecurityAssociation, ok := loadIKESAForMessageIDValidation(ikeMessage)
 	if !ok {
 		// Let handlers process unknown SPI and emit their existing INVALID_IKE_SPI behavior.
+		return true
+	}
+
+	ikeSecurityAssociation.MessageIDMu.Lock()
+	defer ikeSecurityAssociation.MessageIDMu.Unlock()
+
+	if ikeMessage.MessageID == ikeSecurityAssociation.PeerRequestMessageID {
+		ikeLog.Debugf("Accepting retransmitted request MessageID: %d", ikeMessage.MessageID)
 		return true
 	}
 

--- a/pkg/ike/dispatcher.go
+++ b/pkg/ike/dispatcher.go
@@ -56,7 +56,7 @@ func validateAndTrackMessageID(ikeMessage *ike_message.IKEMessage) bool {
 			return false
 		}
 
-		if _, exists := ue.TemporaryExchangeMsgIDChildSAMapping[ikeMessage.MessageID]; !exists {
+		if !ue.HasHalfChildSA(ikeMessage.MessageID) {
 			ikeLog.Warnf(
 				"Unexpected CREATE_CHILD_SA response MessageID: got %d with no pending exchange",
 				ikeMessage.MessageID,
@@ -70,6 +70,14 @@ func validateAndTrackMessageID(ikeMessage *ike_message.IKEMessage) bool {
 	ikeSecurityAssociation, ok := loadIKESAForMessageIDValidation(ikeMessage)
 	if !ok {
 		// Let handlers process unknown SPI and emit their existing INVALID_IKE_SPI behavior.
+		return true
+	}
+
+	ikeSecurityAssociation.MessageIDMu.Lock()
+	defer ikeSecurityAssociation.MessageIDMu.Unlock()
+
+	if ikeMessage.MessageID == ikeSecurityAssociation.PeerRequestMessageID {
+		ikeLog.Debugf("Accepting retransmitted request MessageID: %d", ikeMessage.MessageID)
 		return true
 	}
 

--- a/pkg/ike/dispatcher.go
+++ b/pkg/ike/dispatcher.go
@@ -94,8 +94,6 @@ func validateAndTrackMessageID(ikeMessage *ike_message.IKEMessage) messageIDVali
 		ikeLog.Warnf("Unexpected request MessageID: got %d, expected %d", ikeMessage.MessageID, expectedMessageID)
 		return messageIDValidationDrop
 	}
-	ikeSecurityAssociation.PeerRequestMessageID = ikeMessage.MessageID
-	handler.ForgetCachedIKEResponsesBefore(ikeMessage.ResponderSPI, ikeMessage.MessageID)
 	return messageIDValidationProcess
 }
 

--- a/pkg/ike/dispatcher.go
+++ b/pkg/ike/dispatcher.go
@@ -22,6 +22,18 @@ func isResponseMessage(ikeMessage *ike_message.IKEMessage) bool {
 	return (ikeMessage.Flags & ike_message.ResponseBitCheck) != 0
 }
 
+func loadIKESAForMessageIDValidation(ikeMessage *ike_message.IKEMessage) (*context.IKESecurityAssociation, bool) {
+	if ikeSecurityAssociation, ok := context.TNGFSelf().IKESALoad(ikeMessage.ResponderSPI); ok {
+		return ikeSecurityAssociation, true
+	}
+
+	// TNGF-initiated exchanges should normally retain the original IKE SA SPI
+	// ordering, but some existing CREATE_CHILD_SA paths build outbound headers
+	// with the local SPI in InitiatorSPI. Check both positions so response
+	// validation is not silently bypassed.
+	return context.TNGFSelf().IKESALoad(ikeMessage.InitiatorSPI)
+}
+
 func validateAndTrackMessageID(ikeMessage *ike_message.IKEMessage) bool {
 	if ikeMessage == nil || ikeMessage.ExchangeType == ike_message.IKE_SA_INIT {
 		return true
@@ -32,7 +44,7 @@ func validateAndTrackMessageID(ikeMessage *ike_message.IKEMessage) bool {
 			return true
 		}
 
-		ikeSecurityAssociation, ok := context.TNGFSelf().IKESALoad(ikeMessage.ResponderSPI)
+		ikeSecurityAssociation, ok := loadIKESAForMessageIDValidation(ikeMessage)
 		if !ok {
 			// Let handlers process unknown SPI and emit their existing INVALID_IKE_SPI behavior.
 			return true
@@ -55,7 +67,7 @@ func validateAndTrackMessageID(ikeMessage *ike_message.IKEMessage) bool {
 		return true
 	}
 
-	ikeSecurityAssociation, ok := context.TNGFSelf().IKESALoad(ikeMessage.ResponderSPI)
+	ikeSecurityAssociation, ok := loadIKESAForMessageIDValidation(ikeMessage)
 	if !ok {
 		// Let handlers process unknown SPI and emit their existing INVALID_IKE_SPI behavior.
 		return true

--- a/pkg/ike/dispatcher.go
+++ b/pkg/ike/dispatcher.go
@@ -22,6 +22,14 @@ func isResponseMessage(ikeMessage *ike_message.IKEMessage) bool {
 	return (ikeMessage.Flags & ike_message.ResponseBitCheck) != 0
 }
 
+type messageIDValidationResult int
+
+const (
+	messageIDValidationProcess messageIDValidationResult = iota
+	messageIDValidationDrop
+	messageIDValidationRetransmit
+)
+
 func loadIKESAForMessageIDValidation(ikeMessage *ike_message.IKEMessage) (*context.IKESecurityAssociation, bool) {
 	if ikeSecurityAssociation, ok := context.TNGFSelf().IKESALoad(ikeMessage.ResponderSPI); ok {
 		return ikeSecurityAssociation, true
@@ -34,26 +42,26 @@ func loadIKESAForMessageIDValidation(ikeMessage *ike_message.IKEMessage) (*conte
 	return context.TNGFSelf().IKESALoad(ikeMessage.InitiatorSPI)
 }
 
-func validateAndTrackMessageID(ikeMessage *ike_message.IKEMessage) bool {
+func validateAndTrackMessageID(ikeMessage *ike_message.IKEMessage) messageIDValidationResult {
 	if ikeMessage == nil || ikeMessage.ExchangeType == ike_message.IKE_SA_INIT {
-		return true
+		return messageIDValidationProcess
 	}
 
 	if isResponseMessage(ikeMessage) {
 		if ikeMessage.ExchangeType != ike_message.CREATE_CHILD_SA {
-			return true
+			return messageIDValidationProcess
 		}
 
 		ikeSecurityAssociation, ok := loadIKESAForMessageIDValidation(ikeMessage)
 		if !ok {
 			// Let handlers process unknown SPI and emit their existing INVALID_IKE_SPI behavior.
-			return true
+			return messageIDValidationProcess
 		}
 
 		ue := ikeSecurityAssociation.ThisUE.Load()
 		if ue == nil {
 			ikeLog.Warn("Unexpected CREATE_CHILD_SA response: UE context is nil")
-			return false
+			return messageIDValidationDrop
 		}
 
 		if !ue.HasHalfChildSA(ikeMessage.MessageID) {
@@ -61,33 +69,34 @@ func validateAndTrackMessageID(ikeMessage *ike_message.IKEMessage) bool {
 				"Unexpected CREATE_CHILD_SA response MessageID: got %d with no pending exchange",
 				ikeMessage.MessageID,
 			)
-			return false
+			return messageIDValidationDrop
 		}
 
-		return true
+		return messageIDValidationProcess
 	}
 
 	ikeSecurityAssociation, ok := loadIKESAForMessageIDValidation(ikeMessage)
 	if !ok {
 		// Let handlers process unknown SPI and emit their existing INVALID_IKE_SPI behavior.
-		return true
+		return messageIDValidationProcess
 	}
 
 	ikeSecurityAssociation.MessageIDMu.Lock()
 	defer ikeSecurityAssociation.MessageIDMu.Unlock()
 
 	if ikeMessage.MessageID == ikeSecurityAssociation.PeerRequestMessageID {
-		ikeLog.Debugf("Accepting retransmitted request MessageID: %d", ikeMessage.MessageID)
-		return true
+		ikeLog.Debugf("Retransmitting response for request MessageID: %d", ikeMessage.MessageID)
+		return messageIDValidationRetransmit
 	}
 
 	expectedMessageID := ikeSecurityAssociation.PeerRequestMessageID + 1
 	if ikeMessage.MessageID != expectedMessageID {
 		ikeLog.Warnf("Unexpected request MessageID: got %d, expected %d", ikeMessage.MessageID, expectedMessageID)
-		return false
+		return messageIDValidationDrop
 	}
 	ikeSecurityAssociation.PeerRequestMessageID = ikeMessage.MessageID
-	return true
+	handler.ForgetCachedIKEResponsesBefore(ikeMessage.ResponderSPI, ikeMessage.MessageID)
+	return messageIDValidationProcess
 }
 
 func Dispatch(udpConn *net.UDPConn, localAddr, remoteAddr *net.UDPAddr, msg []byte) {
@@ -125,7 +134,15 @@ func Dispatch(udpConn *net.UDPConn, localAddr, remoteAddr *net.UDPAddr, msg []by
 		return
 	}
 
-	if !validateAndTrackMessageID(ikeMessage) {
+	switch validateAndTrackMessageID(ikeMessage) {
+	case messageIDValidationDrop:
+		return
+	case messageIDValidationRetransmit:
+		if !handler.RetransmitCachedIKEMessageToUE(
+			udpConn, localAddr, remoteAddr, ikeMessage.ResponderSPI, ikeMessage.MessageID,
+		) {
+			ikeLog.Warnf("No cached response for retransmitted request MessageID: %d", ikeMessage.MessageID)
+		}
 		return
 	}
 

--- a/pkg/ike/dispatcher.go
+++ b/pkg/ike/dispatcher.go
@@ -7,6 +7,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/free5gc/tngf/internal/logger"
+	"github.com/free5gc/tngf/pkg/context"
 	"github.com/free5gc/tngf/pkg/ike/handler"
 	ike_message "github.com/free5gc/tngf/pkg/ike/message"
 )
@@ -15,6 +16,58 @@ var ikeLog *logrus.Entry
 
 func init() {
 	ikeLog = logger.IKELog
+}
+
+func isResponseMessage(ikeMessage *ike_message.IKEMessage) bool {
+	return (ikeMessage.Flags & ike_message.ResponseBitCheck) != 0
+}
+
+func validateAndTrackMessageID(ikeMessage *ike_message.IKEMessage) bool {
+	if ikeMessage == nil || ikeMessage.ExchangeType == ike_message.IKE_SA_INIT {
+		return true
+	}
+
+	if isResponseMessage(ikeMessage) {
+		if ikeMessage.ExchangeType != ike_message.CREATE_CHILD_SA {
+			return true
+		}
+
+		ikeSecurityAssociation, ok := context.TNGFSelf().IKESALoad(ikeMessage.ResponderSPI)
+		if !ok {
+			// Let handlers process unknown SPI and emit their existing INVALID_IKE_SPI behavior.
+			return true
+		}
+
+		ue := ikeSecurityAssociation.ThisUE.Load()
+		if ue == nil {
+			ikeLog.Warn("Unexpected CREATE_CHILD_SA response: UE context is nil")
+			return false
+		}
+
+		if _, exists := ue.TemporaryExchangeMsgIDChildSAMapping[ikeMessage.MessageID]; !exists {
+			ikeLog.Warnf(
+				"Unexpected CREATE_CHILD_SA response MessageID: got %d with no pending exchange",
+				ikeMessage.MessageID,
+			)
+			return false
+		}
+
+		return true
+	}
+
+	ikeSecurityAssociation, ok := context.TNGFSelf().IKESALoad(ikeMessage.ResponderSPI)
+	if !ok {
+		// Let handlers process unknown SPI and emit their existing INVALID_IKE_SPI behavior.
+		return true
+	}
+
+	expectedMessageID := ikeSecurityAssociation.PeerRequestMessageID + 1
+	if ikeMessage.MessageID != expectedMessageID {
+		ikeLog.Warnf("Unexpected request MessageID: got %d, expected %d", ikeMessage.MessageID, expectedMessageID)
+		return false
+	}
+	ikeSecurityAssociation.PeerRequestMessageID = ikeMessage.MessageID
+	return true
 }
 
 func Dispatch(udpConn *net.UDPConn, localAddr, remoteAddr *net.UDPAddr, msg []byte) {
@@ -49,6 +102,10 @@ func Dispatch(udpConn *net.UDPConn, localAddr, remoteAddr *net.UDPAddr, msg []by
 	err := ikeMessage.Decode(msg)
 	if err != nil {
 		ikeLog.Error(err)
+		return
+	}
+
+	if !validateAndTrackMessageID(ikeMessage) {
 		return
 	}
 

--- a/pkg/ike/handler/handler.go
+++ b/pkg/ike/handler/handler.go
@@ -281,6 +281,7 @@ func HandleIKESAINIT(udpConn *net.UDPConn, tngfAddr, ueAddr *net.UDPAddr, messag
 	ikeSecurityAssociation := tngfSelf.NewIKESecurityAssociation()
 	ikeSecurityAssociation.RemoteSPI = message.InitiatorSPI
 	ikeSecurityAssociation.InitiatorMessageID = message.MessageID
+	ikeSecurityAssociation.PeerRequestMessageID = message.MessageID
 	ikeSecurityAssociation.UEIsBehindNAT = ueIsBehindNAT
 	ikeSecurityAssociation.TNGFIsBehindNAT = tngfIsBehindNAT
 
@@ -1370,6 +1371,74 @@ func HandleCREATECHILDSA(udpConn *net.UDPConn, tngfAddr, ueAddr *net.UDPAddr, me
 					temporaryPDUSessionSetupData.FailedListSURes, nil)
 			}
 			break
+		}
+	}
+}
+
+func HandleInformational(udpConn *net.UDPConn, tngfAddr, ueAddr *net.UDPAddr, message *ike_message.IKEMessage) {
+	ikeLog.Infoln("Handle INFORMATIONAL")
+
+	if message == nil {
+		ikeLog.Error("IKE Message is nil")
+		return
+	}
+
+	ikeSecurityAssociation, ok := context.TNGFSelf().IKESALoad(message.ResponderSPI)
+	if !ok {
+		ikeLog.Warnf("Received INFORMATIONAL for unrecognized SPI: 0x%x", message.ResponderSPI)
+		return
+	}
+
+	var encryptedPayload *ike_message.Encrypted
+	for _, ikePayload := range message.Payloads {
+		switch ikePayload.Type() {
+		case ike_message.TypeSK:
+			encryptedPayload = ikePayload.(*ike_message.Encrypted)
+		default:
+			ikeLog.Warnf(
+				"Get IKE payload (type %d) in INFORMATIONAL message, this payload will not be handled by IKE handler",
+				ikePayload.Type())
+		}
+	}
+
+	if encryptedPayload == nil {
+		ikeLog.Warn("INFORMATIONAL message has no encrypted payload")
+		return
+	}
+
+	decryptedIKEPayload, err := DecryptProcedure(ikeSecurityAssociation, message, encryptedPayload)
+	if err != nil {
+		ikeLog.Errorf("Decrypt INFORMATIONAL message failed: %+v", err)
+		return
+	}
+
+	for _, ikePayload := range decryptedIKEPayload {
+		if ikePayload.Type() != ike_message.TypeD {
+			continue
+		}
+
+		deletePayload := ikePayload.(*ike_message.Delete)
+		switch deletePayload.ProtocolID {
+		case ike_message.TypeIKE:
+			ikeLog.Info("Received IKE SA DELETE")
+			if ikeSecurityAssociation.ThisUE != nil {
+				ikeSecurityAssociation.ThisUE.Remove()
+			} else {
+				context.TNGFSelf().DeleteIKESecurityAssociation(ikeSecurityAssociation.LocalSPI)
+			}
+		case ike_message.TypeESP:
+			if deletePayload.SPISize != 4 {
+				ikeLog.Warnf("Unexpected ESP SPI size in DELETE payload: %d", deletePayload.SPISize)
+				continue
+			}
+
+			for offset := 0; offset+4 <= len(deletePayload.SPIs); offset += 4 {
+				inboundSPI := binary.BigEndian.Uint32(deletePayload.SPIs[offset : offset+4])
+				context.TNGFSelf().ChildSA.Delete(inboundSPI)
+				if ikeSecurityAssociation.ThisUE != nil {
+					delete(ikeSecurityAssociation.ThisUE.TNGFChildSecurityAssociation, inboundSPI)
+				}
+			}
 		}
 	}
 }

--- a/pkg/ike/handler/handler.go
+++ b/pkg/ike/handler/handler.go
@@ -1001,7 +1001,8 @@ func HandleIKEAUTH(udpConn *net.UDPConn, tngfAddr, ueAddr *net.UDPAddr, message 
 					continue
 				}
 
-				SendIKEMessageToUE(udpConn, tngfAddr, ueAddr, responseIKEMessage)
+				thisUE.CreateHalfChildSA(ikeSecurityAssociation.InitiatorMessageID, spi, pduSessionID)
+				SendIKEMessageToUE(udpConn, tngfAddr, ueAddr, ikeMessage)
 				break
 			} else {
 				// Send Initial Context Setup Response to AMF
@@ -1356,7 +1357,8 @@ func HandleCREATECHILDSA(udpConn *net.UDPConn, tngfAddr, ueAddr *net.UDPAddr, me
 				continue
 			}
 
-			SendIKEMessageToUE(udpConn, tngfAddr, ueAddr, responseIKEMessage)
+			thisUE.CreateHalfChildSA(ikeSecurityAssociation.ResponderMessageID, spi, tmp_pduSessionID)
+			SendIKEMessageToUE(udpConn, tngfAddr, ueAddr, ikeMessage)
 			break
 		} else {
 			// Send Response to AMF
@@ -1411,6 +1413,19 @@ func HandleInformational(udpConn *net.UDPConn, tngfAddr, ueAddr *net.UDPAddr, me
 		ikeLog.Errorf("Decrypt INFORMATIONAL message failed: %+v", err)
 		return
 	}
+
+	responseIKEMessage := new(ike_message.IKEMessage)
+	responseIKEMessage.BuildIKEHeader(message.InitiatorSPI, message.ResponderSPI,
+		ike_message.INFORMATIONAL, ike_message.ResponseBitCheck, message.MessageID)
+	responseIKEMessage.Payloads.Reset()
+
+	var responseIKEPayload ike_message.IKEPayloadContainer
+	if encryptErr := EncryptProcedure(ikeSecurityAssociation, responseIKEPayload, responseIKEMessage); encryptErr != nil {
+		ikeLog.Errorf("Encrypt INFORMATIONAL response failed: %+v", encryptErr)
+		return
+	}
+
+	SendIKEMessageToUE(udpConn, tngfAddr, ueAddr, responseIKEMessage)
 
 	for _, ikePayload := range decryptedIKEPayload {
 		if ikePayload.Type() != ike_message.TypeD {

--- a/pkg/ike/handler/handler.go
+++ b/pkg/ike/handler/handler.go
@@ -1502,9 +1502,7 @@ func handleInformationalDeletePayload(
 			spi := binary.BigEndian.Uint32(deletePayload.SPIs[offset : offset+4])
 			tngfSelf.ChildSA.Delete(spi)
 			if ue := ikeSecurityAssociation.ThisUE.Load(); ue != nil {
-				ue.ChildSAMu.Lock()
-				delete(ue.TNGFChildSecurityAssociation, spi)
-				ue.ChildSAMu.Unlock()
+				ue.DeleteChildSA(spi)
 			}
 		}
 	case ike_message.TypeIKE:

--- a/pkg/ike/handler/handler.go
+++ b/pkg/ike/handler/handler.go
@@ -1428,6 +1428,14 @@ func HandleInformational(udpConn *net.UDPConn, tngfAddr, ueAddr *net.UDPAddr, me
 	ikeSecurityAssociation, ok := tngfSelf.IKESALoad(localSPI)
 	if !ok {
 		ikeLog.Warnf("Received INFORMATIONAL for unrecognized SPI: responder=0x%x", message.ResponderSPI)
+		if (message.Flags & ike_message.ResponseBitCheck) == 0 {
+			responseIKEMessage := new(ike_message.IKEMessage)
+			responseIKEMessage.BuildIKEHeader(message.InitiatorSPI, 0,
+				ike_message.INFORMATIONAL, ike_message.ResponseBitCheck, message.MessageID)
+			responseIKEMessage.Payloads.Reset()
+			responseIKEMessage.Payloads.BuildNotification(ike_message.TypeNone, ike_message.INVALID_IKE_SPI, nil, nil)
+			SendIKEMessageToUE(udpConn, tngfAddr, ueAddr, responseIKEMessage)
+		}
 		return
 	}
 

--- a/pkg/ike/handler/handler.go
+++ b/pkg/ike/handler/handler.go
@@ -1028,7 +1028,8 @@ func HandleIKEAUTH(udpConn *net.UDPConn, tngfAddr, ueAddr *net.UDPAddr, message 
 					continue
 				}
 
-				SendIKEMessageToUE(udpConn, tngfAddr, ueAddr, responseIKEMessage)
+				thisUE.CreateHalfChildSA(ikeSecurityAssociation.InitiatorMessageID, spi, pduSessionID)
+				SendIKEMessageToUE(udpConn, tngfAddr, ueAddr, ikeMessage)
 				break
 			} else {
 				// Send Initial Context Setup Response to AMF
@@ -1393,7 +1394,8 @@ func HandleCREATECHILDSA(udpConn *net.UDPConn, tngfAddr, ueAddr *net.UDPAddr, me
 				continue
 			}
 
-			SendIKEMessageToUE(udpConn, tngfAddr, ueAddr, responseIKEMessage)
+			thisUE.CreateHalfChildSA(ikeSecurityAssociation.ResponderMessageID, spi, tmp_pduSessionID)
+			SendIKEMessageToUE(udpConn, tngfAddr, ueAddr, ikeMessage)
 			break
 		} else {
 			// Send Response to AMF
@@ -1429,6 +1431,24 @@ func HandleInformational(udpConn *net.UDPConn, tngfAddr, ueAddr *net.UDPAddr, me
 		return
 	}
 
+	// RFC 7296 §2.21: every INFORMATIONAL request must receive an empty INFORMATIONAL response.
+	// Send it before processing delete payloads below, since a Delete(IKE) payload can tear down
+	// this ikeSecurityAssociation.
+	responseIKEMessage := new(ike_message.IKEMessage)
+	var responseIKEPayload ike_message.IKEPayloadContainer
+	responseIKEMessage.BuildIKEHeader(
+		ikeSecurityAssociation.RemoteSPI,
+		ikeSecurityAssociation.LocalSPI,
+		ike_message.INFORMATIONAL,
+		ike_message.ResponseBitCheck,
+		message.MessageID,
+	)
+	if err := EncryptProcedure(ikeSecurityAssociation, responseIKEPayload, responseIKEMessage); err != nil {
+		ikeLog.Errorf("Encrypting INFORMATIONAL response failed: %+v", err)
+		return
+	}
+	SendIKEMessageToUE(udpConn, tngfAddr, ueAddr, responseIKEMessage)
+
 	for _, payload := range message.Payloads {
 		if encryptedPayload, isEncrypted := payload.(*ike_message.Encrypted); isEncrypted {
 			decryptedPayloads, err := DecryptProcedure(ikeSecurityAssociation, message, encryptedPayload)
@@ -1452,22 +1472,6 @@ func HandleInformational(udpConn *net.UDPConn, tngfAddr, ueAddr *net.UDPAddr, me
 		}
 		handleInformationalDeletePayload(tngfSelf, ikeSecurityAssociation, deletePayload)
 	}
-
-	// RFC 7296 §2.21: every INFORMATIONAL request must receive an empty INFORMATIONAL response
-	responseIKEMessage := new(ike_message.IKEMessage)
-	var responseIKEPayload ike_message.IKEPayloadContainer
-	responseIKEMessage.BuildIKEHeader(
-		ikeSecurityAssociation.RemoteSPI,
-		ikeSecurityAssociation.LocalSPI,
-		ike_message.INFORMATIONAL,
-		ike_message.ResponseBitCheck,
-		message.MessageID,
-	)
-	if err := EncryptProcedure(ikeSecurityAssociation, responseIKEPayload, responseIKEMessage); err != nil {
-		ikeLog.Errorf("Encrypting INFORMATIONAL response failed: %+v", err)
-		return
-	}
-	SendIKEMessageToUE(udpConn, tngfAddr, ueAddr, responseIKEMessage)
 }
 
 func handleInformationalDeletePayload(

--- a/pkg/ike/handler/handler.go
+++ b/pkg/ike/handler/handler.go
@@ -302,6 +302,7 @@ func HandleIKESAINIT(udpConn *net.UDPConn, tngfAddr, ueAddr *net.UDPAddr, messag
 	}
 	ikeSecurityAssociation.RemoteSPI = message.InitiatorSPI
 	ikeSecurityAssociation.InitiatorMessageID = message.MessageID
+	ikeSecurityAssociation.PeerRequestMessageID = message.MessageID
 	ikeSecurityAssociation.UEIsBehindNAT = ueIsBehindNAT
 	ikeSecurityAssociation.TNGFIsBehindNAT = tngfIsBehindNAT
 

--- a/pkg/ike/handler/security.go
+++ b/pkg/ike/handler/security.go
@@ -653,9 +653,6 @@ func EncryptProcedure(ikeSecurityAssociation *context.IKESecurityAssociation,
 	if ikeSecurityAssociation == nil {
 		return errors.New("IKE SA is nil")
 	}
-	if len(ikePayload) == 0 {
-		return errors.New("no IKE payload to be encrypted")
-	}
 	if responseIKEMessage == nil {
 		return errors.New("response IKE message is nil")
 	}
@@ -703,7 +700,11 @@ func EncryptProcedure(ikeSecurityAssociation *context.IKESecurityAssociation,
 	}
 
 	encryptedData = append(encryptedData, make([]byte, checksumLength)...)
-	sk := responseIKEMessage.Payloads.BuildEncrypted(ikePayload[0].Type(), encryptedData)
+	nextPayload := message.IKEPayloadType(message.NoNext)
+	if len(ikePayload) > 0 {
+		nextPayload = ikePayload[0].Type()
+	}
+	sk := responseIKEMessage.Payloads.BuildEncrypted(nextPayload, encryptedData)
 
 	// Calculate checksum
 	responseIKEMessageData, err := responseIKEMessage.Encode()

--- a/pkg/ike/handler/security.go
+++ b/pkg/ike/handler/security.go
@@ -673,9 +673,6 @@ func EncryptProcedure(ikeSecurityAssociation *context.IKESecurityAssociation,
 	if ikeSecurityAssociation == nil {
 		return errors.New("IKE SA is nil")
 	}
-	if len(ikePayload) == 0 {
-		return errors.New("no IKE payload to be encrypted")
-	}
 	if responseIKEMessage == nil {
 		return errors.New("response IKE message is nil")
 	}
@@ -723,7 +720,11 @@ func EncryptProcedure(ikeSecurityAssociation *context.IKESecurityAssociation,
 	}
 
 	encryptedData = append(encryptedData, make([]byte, checksumLength)...)
-	sk := responseIKEMessage.Payloads.BuildEncrypted(ikePayload[0].Type(), encryptedData)
+	nextPayload := message.IKEPayloadType(message.NoNext)
+	if len(ikePayload) > 0 {
+		nextPayload = ikePayload[0].Type()
+	}
+	sk := responseIKEMessage.Payloads.BuildEncrypted(nextPayload, encryptedData)
 
 	// Calculate checksum
 	responseIKEMessageData, err := responseIKEMessage.Encode()

--- a/pkg/ike/handler/send.go
+++ b/pkg/ike/handler/send.go
@@ -2,25 +2,53 @@ package handler
 
 import (
 	"net"
+	"sync"
+	"time"
 
 	ike_message "github.com/free5gc/tngf/pkg/ike/message"
 )
 
-func SendIKEMessageToUE(udpConn *net.UDPConn, srcAddr, dstAddr *net.UDPAddr, message *ike_message.IKEMessage) {
-	ikeLog.Trace("Send IKE message to UE")
-	ikeLog.Trace("Encoding...")
-	pkt, err := message.Encode()
-	if err != nil {
-		ikeLog.Errorln(err)
+type cachedResponseKey struct {
+	responderSPI uint64
+	messageID    uint32
+}
+
+type cachedResponse struct {
+	packet    []byte
+	expiresAt time.Time
+}
+
+const cachedResponseLifetime = 5 * time.Minute
+
+var cachedResponses sync.Map
+
+func cacheIKEMessageResponse(message *ike_message.IKEMessage, packet []byte) {
+	if message == nil || message.ExchangeType == ike_message.IKE_SA_INIT ||
+		(message.Flags&ike_message.ResponseBitCheck) == 0 {
 		return
 	}
+
+	key := cachedResponseKey{
+		responderSPI: message.ResponderSPI,
+		messageID:    message.MessageID,
+	}
+	cachedResponses.Store(key, cachedResponse{
+		packet:    append([]byte(nil), packet...),
+		expiresAt: time.Now().Add(cachedResponseLifetime),
+	})
+}
+
+func buildIKEPacketForUDP(srcAddr *net.UDPAddr, pkt []byte) []byte {
 	// As specified in RFC 7296 section 3.1, the IKE message send from/to UDP port 4500
 	// should prepend a 4 bytes zero
-	if srcAddr.Port == 4500 {
+	if srcAddr != nil && srcAddr.Port == 4500 {
 		prependZero := make([]byte, 4)
-		pkt = append(prependZero, pkt...)
+		return append(prependZero, pkt...)
 	}
+	return pkt
+}
 
+func sendIKEPacketToUE(udpConn *net.UDPConn, dstAddr *net.UDPAddr, pkt []byte) {
 	ikeLog.Trace("Sending...")
 	n, err := udpConn.WriteToUDP(pkt, dstAddr)
 	if err != nil {
@@ -31,4 +59,66 @@ func SendIKEMessageToUE(udpConn *net.UDPConn, srcAddr, dstAddr *net.UDPAddr, mes
 		ikeLog.Errorf("Not all of the data is sent. Total length: %d. Sent: %d.", len(pkt), n)
 		return
 	}
+}
+
+func cleanupExpiredCachedResponses(now time.Time) {
+	cachedResponses.Range(func(key, value interface{}) bool {
+		response := value.(cachedResponse)
+		if now.After(response.expiresAt) {
+			cachedResponses.Delete(key)
+		}
+		return true
+	})
+}
+
+func ForgetCachedIKEResponsesBefore(responderSPI uint64, messageID uint32) {
+	now := time.Now()
+	cachedResponses.Range(func(key, value interface{}) bool {
+		responseKey := key.(cachedResponseKey)
+		response := value.(cachedResponse)
+		if now.After(response.expiresAt) ||
+			(responseKey.responderSPI == responderSPI && responseKey.messageID < messageID) {
+			cachedResponses.Delete(key)
+		}
+		return true
+	})
+}
+
+func RetransmitCachedIKEMessageToUE(
+	udpConn *net.UDPConn,
+	_ *net.UDPAddr,
+	dstAddr *net.UDPAddr,
+	responderSPI uint64,
+	messageID uint32,
+) bool {
+	key := cachedResponseKey{
+		responderSPI: responderSPI,
+		messageID:    messageID,
+	}
+	cachedResponseValue, ok := cachedResponses.Load(key)
+	if !ok {
+		return false
+	}
+	response := cachedResponseValue.(cachedResponse)
+	if time.Now().After(response.expiresAt) {
+		cachedResponses.Delete(key)
+		return false
+	}
+
+	sendIKEPacketToUE(udpConn, dstAddr, append([]byte(nil), response.packet...))
+	return true
+}
+
+func SendIKEMessageToUE(udpConn *net.UDPConn, srcAddr, dstAddr *net.UDPAddr, message *ike_message.IKEMessage) {
+	ikeLog.Trace("Send IKE message to UE")
+	ikeLog.Trace("Encoding...")
+	pkt, err := message.Encode()
+	if err != nil {
+		ikeLog.Errorln(err)
+		return
+	}
+	pkt = buildIKEPacketForUDP(srcAddr, pkt)
+	cleanupExpiredCachedResponses(time.Now())
+	cacheIKEMessageResponse(message, pkt)
+	sendIKEPacketToUE(udpConn, dstAddr, pkt)
 }

--- a/pkg/ike/handler/send.go
+++ b/pkg/ike/handler/send.go
@@ -42,6 +42,9 @@ func cacheIKEMessageResponse(message *ike_message.IKEMessage, packet []byte) {
 		(message.Flags&ike_message.ResponseBitCheck) == 0 {
 		return
 	}
+	if _, ok := context.TNGFSelf().IKESALoad(message.ResponderSPI); !ok {
+		return
+	}
 
 	key := cachedResponseKey{
 		responderSPI: message.ResponderSPI,

--- a/pkg/ike/handler/send.go
+++ b/pkg/ike/handler/send.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/free5gc/tngf/pkg/context"
 	ike_message "github.com/free5gc/tngf/pkg/ike/message"
 )
 
@@ -19,8 +20,20 @@ type cachedResponse struct {
 }
 
 const cachedResponseLifetime = 5 * time.Minute
+const cachedResponseCleanupInterval = time.Minute
 
 var cachedResponses sync.Map
+
+func init() {
+	go func() {
+		ticker := time.NewTicker(cachedResponseCleanupInterval)
+		defer ticker.Stop()
+
+		for now := range ticker.C {
+			cleanupExpiredCachedResponses(now)
+		}
+	}()
+}
 
 func cacheIKEMessageResponse(message *ike_message.IKEMessage, packet []byte) {
 	if message == nil || message.ExchangeType == ike_message.IKE_SA_INIT ||
@@ -84,6 +97,29 @@ func ForgetCachedIKEResponsesBefore(responderSPI uint64, messageID uint32) {
 	})
 }
 
+func markPeerRequestMessageIDProcessed(message *ike_message.IKEMessage) {
+	if message == nil || message.ExchangeType == ike_message.IKE_SA_INIT ||
+		(message.Flags&ike_message.ResponseBitCheck) == 0 {
+		return
+	}
+
+	ikeSecurityAssociation, ok := context.TNGFSelf().IKESALoad(message.ResponderSPI)
+	if !ok {
+		return
+	}
+
+	ikeSecurityAssociation.MessageIDMu.Lock()
+	defer ikeSecurityAssociation.MessageIDMu.Unlock()
+
+	expectedMessageID := ikeSecurityAssociation.PeerRequestMessageID + 1
+	if message.MessageID != expectedMessageID {
+		return
+	}
+
+	ikeSecurityAssociation.PeerRequestMessageID = message.MessageID
+	ForgetCachedIKEResponsesBefore(message.ResponderSPI, message.MessageID)
+}
+
 func RetransmitCachedIKEMessageToUE(
 	udpConn *net.UDPConn,
 	_ *net.UDPAddr,
@@ -120,5 +156,6 @@ func SendIKEMessageToUE(udpConn *net.UDPConn, srcAddr, dstAddr *net.UDPAddr, mes
 	pkt = buildIKEPacketForUDP(srcAddr, pkt)
 	cleanupExpiredCachedResponses(time.Now())
 	cacheIKEMessageResponse(message, pkt)
+	markPeerRequestMessageIDProcessed(message)
 	sendIKEPacketToUE(udpConn, dstAddr, pkt)
 }

--- a/pkg/ike/handler/send.go
+++ b/pkg/ike/handler/send.go
@@ -28,6 +28,12 @@ var cachedResponses sync.Map
 
 func init() {
 	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				ikeLog.Errorf("panic in cached response cleanup goroutine: %v", r)
+			}
+		}()
+
 		ticker := time.NewTicker(cachedResponseCleanupInterval)
 		defer ticker.Stop()
 
@@ -81,7 +87,11 @@ func sendIKEPacketToUE(udpConn *net.UDPConn, dstAddr *net.UDPAddr, pkt []byte) {
 
 func cleanupExpiredCachedResponses(now time.Time) {
 	cachedResponses.Range(func(key, value interface{}) bool {
-		response := value.(cachedResponse)
+		response, ok := value.(cachedResponse)
+		if !ok {
+			cachedResponses.Delete(key)
+			return true
+		}
 		if now.After(response.expiresAt) {
 			cachedResponses.Delete(key)
 		}
@@ -92,8 +102,12 @@ func cleanupExpiredCachedResponses(now time.Time) {
 func ForgetCachedIKEResponsesBefore(responderSPI uint64, messageID uint32) {
 	now := time.Now()
 	cachedResponses.Range(func(key, value interface{}) bool {
-		responseKey := key.(cachedResponseKey)
-		response := value.(cachedResponse)
+		responseKey, keyOk := key.(cachedResponseKey)
+		response, valOk := value.(cachedResponse)
+		if !keyOk || !valOk {
+			cachedResponses.Delete(key)
+			return true
+		}
 		if now.After(response.expiresAt) ||
 			(responseKey.responderSPI == responderSPI && responseKey.messageID < messageID) {
 			cachedResponses.Delete(key)
@@ -140,7 +154,11 @@ func RetransmitCachedIKEMessageToUE(
 	if !ok {
 		return false
 	}
-	response := cachedResponseValue.(cachedResponse)
+	response, ok := cachedResponseValue.(cachedResponse)
+	if !ok {
+		cachedResponses.Delete(key)
+		return false
+	}
 	if time.Now().After(response.expiresAt) {
 		cachedResponses.Delete(key)
 		return false

--- a/pkg/ike/handler/send.go
+++ b/pkg/ike/handler/send.go
@@ -19,8 +19,10 @@ type cachedResponse struct {
 	expiresAt time.Time
 }
 
-const cachedResponseLifetime = 5 * time.Minute
-const cachedResponseCleanupInterval = time.Minute
+const (
+	cachedResponseLifetime        = 5 * time.Minute
+	cachedResponseCleanupInterval = time.Minute
+)
 
 var cachedResponses sync.Map
 


### PR DESCRIPTION
Closes https://github.com/free5gc/free5gc/issues/995

Adds minimal IKE Message ID validation to block out-of-order/replayed exchanges.
Wires INFORMATIONAL exchange handling and basic DELETE-path safety.
