### PR TITLE
fix: implement IKE SA management and cleanup logic (#1000)

### DIFF
--- a/internal/nwtup/service/service.go
+++ b/internal/nwtup/service/service.go
@@ -104,6 +104,7 @@ func forward(ueInnerIP string, ifIndex int, rawData []byte) {
 
 	var pduSession *tngf_context.PDUSession
 
+	ue.ChildSAMu.RLock()
 	for _, childSA := range ue.TNGFChildSecurityAssociation {
 		// Check which child SA the packet come from with interface index,
 		// and find the corresponding PDU session
@@ -111,6 +112,7 @@ func forward(ueInnerIP string, ifIndex int, rawData []byte) {
 			pduSession = ue.PduSessionList[childSA.PDUSessionIds[0]]
 		}
 	}
+	ue.ChildSAMu.RUnlock()
 
 	if pduSession == nil {
 		nwtupLog.Error("This UE doesn't have any available PDU session")

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -8,6 +8,7 @@ import (
 	"math/big"
 	"net"
 	"sync"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	gtpv1 "github.com/wmnsk/go-gtp/gtpv1"
@@ -24,6 +25,11 @@ var contextLog *logrus.Entry
 var tngfContext = TNGFContext{}
 
 const RadiusDefaultSecret = "free5GC"
+
+var (
+	maxIKESecurityAssociations         = 4096
+	unauthenticatedIKESAExpireDuration = 5 * time.Minute
+)
 
 type TNGFContext struct {
 	NFInfo           TNGFNFInfo
@@ -177,7 +183,15 @@ func (context *TNGFContext) AMFReInitAvailableListStore(sctpAddr string, flag bo
 }
 
 func (context *TNGFContext) NewIKESecurityAssociation() *IKESecurityAssociation {
-	ikeSecurityAssociation := new(IKESecurityAssociation)
+	now := time.Now()
+	context.cleanupExpiredUnauthenticatedIKESA(now)
+
+	if context.currentIKESACount() >= maxIKESecurityAssociations {
+		contextLog.Warn("[Context] IKE SA pool is full; reject new IKE SA")
+		return nil
+	}
+
+	ikeSecurityAssociation := &IKESecurityAssociation{CreatedAt: now}
 
 	maxSPI := new(big.Int).SetUint64(math.MaxUint64)
 	var localSPIuint64 uint64
@@ -197,6 +211,36 @@ func (context *TNGFContext) NewIKESecurityAssociation() *IKESecurityAssociation 
 	ikeSecurityAssociation.LocalSPI = localSPIuint64
 
 	return ikeSecurityAssociation
+}
+
+func (context *TNGFContext) cleanupExpiredUnauthenticatedIKESA(now time.Time) {
+	context.IKESA.Range(func(key, value interface{}) bool {
+		ikeSecurityAssociation, ok := value.(*IKESecurityAssociation)
+		if !ok {
+			context.IKESA.Delete(key)
+			return true
+		}
+
+		if ikeSecurityAssociation.ThisUE != nil {
+			return true
+		}
+
+		if ikeSecurityAssociation.CreatedAt.IsZero() ||
+			now.Sub(ikeSecurityAssociation.CreatedAt) > unauthenticatedIKESAExpireDuration {
+			context.IKESA.Delete(key)
+		}
+
+		return true
+	})
+}
+
+func (context *TNGFContext) currentIKESACount() int {
+	count := 0
+	context.IKESA.Range(func(_, _ interface{}) bool {
+		count++
+		return true
+	})
+	return count
 }
 
 func (context *TNGFContext) DeleteIKESecurityAssociation(spi uint64) {

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -8,6 +8,7 @@ import (
 	"math/big"
 	"net"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -43,7 +44,8 @@ type TNGFContext struct {
 	UePool                 sync.Map // map[int64]*TNGFUe, RanUeNgapID as key
 	AMFPool                sync.Map // map[string]*TNGFAMF, SCTPAddr as key
 	AMFReInitAvailableList sync.Map // map[string]bool, SCTPAddr as key
-	IKESA                  sync.Map // map[uint64]*IKESecurityAssociation, SPI as key
+	IKESA                  sync.Map    // map[uint64]*IKESecurityAssociation, SPI as key
+	ikeSACount             atomic.Int64
 	ChildSA                sync.Map // map[uint32]*ChildSecurityAssociation, inboundSPI as key
 	GTPConnectionWithUPF   sync.Map // map[string]*gtpv1.UPlaneConn, UPF address as key
 	AllocatedUEIPAddress   sync.Map // map[string]*TNGFUe, IPAddr as key
@@ -186,7 +188,8 @@ func (context *TNGFContext) NewIKESecurityAssociation() *IKESecurityAssociation 
 	now := time.Now()
 	context.cleanupExpiredUnauthenticatedIKESA(now)
 
-	if context.currentIKESACount() >= maxIKESecurityAssociations {
+	if context.ikeSACount.Add(1) > int64(maxIKESecurityAssociations) {
+		context.ikeSACount.Add(-1)
 		contextLog.Warn("[Context] IKE SA pool is full; reject new IKE SA")
 		return nil
 	}
@@ -199,6 +202,7 @@ func (context *TNGFContext) NewIKESecurityAssociation() *IKESecurityAssociation 
 	for {
 		localSPI, err := rand.Int(rand.Reader, maxSPI)
 		if err != nil {
+			context.ikeSACount.Add(-1)
 			contextLog.Error("[Context] Error occurs when generate new IKE SPI")
 			return nil
 		}
@@ -217,34 +221,31 @@ func (context *TNGFContext) cleanupExpiredUnauthenticatedIKESA(now time.Time) {
 	context.IKESA.Range(func(key, value interface{}) bool {
 		ikeSecurityAssociation, ok := value.(*IKESecurityAssociation)
 		if !ok {
-			context.IKESA.Delete(key)
+			if _, deleted := context.IKESA.LoadAndDelete(key); deleted {
+				context.ikeSACount.Add(-1)
+			}
 			return true
 		}
 
-		if ikeSecurityAssociation.ThisUE != nil {
+		if ikeSecurityAssociation.ThisUE.Load() != nil {
 			return true
 		}
 
 		if ikeSecurityAssociation.CreatedAt.IsZero() ||
 			now.Sub(ikeSecurityAssociation.CreatedAt) > unauthenticatedIKESAExpireDuration {
-			context.IKESA.Delete(key)
+			if _, deleted := context.IKESA.LoadAndDelete(key); deleted {
+				context.ikeSACount.Add(-1)
+			}
 		}
 
 		return true
 	})
 }
 
-func (context *TNGFContext) currentIKESACount() int {
-	count := 0
-	context.IKESA.Range(func(_, _ interface{}) bool {
-		count++
-		return true
-	})
-	return count
-}
-
 func (context *TNGFContext) DeleteIKESecurityAssociation(spi uint64) {
-	context.IKESA.Delete(spi)
+	if _, loaded := context.IKESA.LoadAndDelete(spi); loaded {
+		context.ikeSACount.Add(-1)
+	}
 }
 
 func (context *TNGFContext) UELoadbyIDi(idi []byte) *TNGFUe {

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -44,7 +44,7 @@ type TNGFContext struct {
 	UePool                 sync.Map // map[int64]*TNGFUe, RanUeNgapID as key
 	AMFPool                sync.Map // map[string]*TNGFAMF, SCTPAddr as key
 	AMFReInitAvailableList sync.Map // map[string]bool, SCTPAddr as key
-	IKESA                  sync.Map    // map[uint64]*IKESecurityAssociation, SPI as key
+	IKESA                  sync.Map // map[uint64]*IKESecurityAssociation, SPI as key
 	ikeSACount             atomic.Int64
 	ChildSA                sync.Map // map[uint32]*ChildSecurityAssociation, inboundSPI as key
 	GTPConnectionWithUPF   sync.Map // map[string]*gtpv1.UPlaneConn, UPF address as key

--- a/pkg/context/ue.go
+++ b/pkg/context/ue.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"time"
 
 	"github.com/vishvananda/netlink"
 	gtpv1 "github.com/wmnsk/go-gtp/gtpv1"
@@ -139,6 +140,8 @@ type GTPConnectionInfo struct {
 }
 
 type IKESecurityAssociation struct {
+	CreatedAt time.Time
+
 	// SPI
 	RemoteSPI uint64
 	LocalSPI  uint64

--- a/pkg/context/ue.go
+++ b/pkg/context/ue.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/vishvananda/netlink"
@@ -67,6 +69,7 @@ type TNGFUe struct {
 
 	/* IKE Security Association */
 	TNGFIKESecurityAssociation   *IKESecurityAssociation
+	ChildSAMu                    sync.RWMutex
 	TNGFChildSecurityAssociation map[uint32]*ChildSecurityAssociation // inbound SPI as key
 	SignallingIPsecSAEstablished bool
 
@@ -192,8 +195,8 @@ type IKESecurityAssociation struct {
 	// If TNGFIsBehindNAT == true, TNGF should send UDP keepalive periodically
 	TNGFIsBehindNAT bool
 
-	// UE context
-	ThisUE *TNGFUe
+	// UE context — atomic to allow race-free read from cleanup goroutine
+	ThisUE atomic.Pointer[TNGFUe]
 }
 
 type ChildSecurityAssociation struct {
@@ -331,7 +334,9 @@ func (ue *TNGFUe) CompleteChildSA(msgID uint32, outboundSPI uint32,
 	}
 
 	// Record to UE context with inbound SPI as key
+	ue.ChildSAMu.Lock()
 	ue.TNGFChildSecurityAssociation[childSA.InboundSPI] = childSA
+	ue.ChildSAMu.Unlock()
 	// Record to TNGF context with inbound SPI as key
 	tngfContext.ChildSA.Store(childSA.InboundSPI, childSA)
 

--- a/pkg/ike/dispatcher.go
+++ b/pkg/ike/dispatcher.go
@@ -54,6 +54,8 @@ func Dispatch(udpConn *net.UDPConn, localAddr, remoteAddr *net.UDPAddr, msg []by
 		handler.HandleIKEAUTH(udpConn, localAddr, remoteAddr, ikeMessage)
 	case ike_message.CREATE_CHILD_SA:
 		handler.HandleCREATECHILDSA(udpConn, localAddr, remoteAddr, ikeMessage)
+	case ike_message.INFORMATIONAL:
+		handler.HandleInformational(udpConn, localAddr, remoteAddr, ikeMessage)
 	default:
 		ikeLog.Warnf("Unimplemented IKE message type, exchange type: %d", ikeMessage.ExchangeType)
 	}

--- a/pkg/ike/handler/handler.go
+++ b/pkg/ike/handler/handler.go
@@ -279,6 +279,16 @@ func HandleIKESAINIT(udpConn *net.UDPConn, tngfAddr, ueAddr *net.UDPAddr, messag
 
 	// Create new IKE security association
 	ikeSecurityAssociation := tngfSelf.NewIKESecurityAssociation()
+	if ikeSecurityAssociation == nil {
+		ikeLog.Warn("Failed to allocate new IKE SA")
+		responseIKEMessage.BuildIKEHeader(message.InitiatorSPI, message.ResponderSPI,
+			ike_message.IKE_SA_INIT, ike_message.ResponseBitCheck, message.MessageID)
+		responseIKEMessage.Payloads.Reset()
+		responseIKEMessage.Payloads.BuildNotification(ike_message.TypeNone, ike_message.TEMPORARY_FAILURE, nil, nil)
+
+		SendIKEMessageToUE(udpConn, tngfAddr, ueAddr, responseIKEMessage)
+		return
+	}
 	ikeSecurityAssociation.RemoteSPI = message.InitiatorSPI
 	ikeSecurityAssociation.InitiatorMessageID = message.MessageID
 	ikeSecurityAssociation.UEIsBehindNAT = ueIsBehindNAT
@@ -1371,6 +1381,76 @@ func HandleCREATECHILDSA(udpConn *net.UDPConn, tngfAddr, ueAddr *net.UDPAddr, me
 			}
 			break
 		}
+	}
+}
+
+func HandleInformational(udpConn *net.UDPConn, tngfAddr, ueAddr *net.UDPAddr, message *ike_message.IKEMessage) {
+	ikeLog.Info("Handle INFORMATIONAL")
+
+	if message == nil {
+		ikeLog.Error("IKE Message is nil")
+		return
+	}
+
+	tngfSelf := context.TNGFSelf()
+	localSPI := message.ResponderSPI
+
+	ikeSecurityAssociation, ok := tngfSelf.IKESALoad(localSPI)
+	if !ok {
+		ikeLog.Warnf("Received INFORMATIONAL for unrecognized SPI: responder=0x%x", message.ResponderSPI)
+		return
+	}
+
+	for _, payload := range message.Payloads {
+		if encryptedPayload, isEncrypted := payload.(*ike_message.Encrypted); isEncrypted {
+			decryptedPayloads, err := DecryptProcedure(ikeSecurityAssociation, message, encryptedPayload)
+			if err != nil {
+				ikeLog.Errorf("Decrypt INFORMATIONAL message failed: %+v", err)
+				return
+			}
+			for _, decryptedPayload := range decryptedPayloads {
+				deletePayload, isDelete := decryptedPayload.(*ike_message.Delete)
+				if !isDelete {
+					continue
+				}
+				handleInformationalDeletePayload(tngfSelf, ikeSecurityAssociation, deletePayload)
+			}
+			continue
+		}
+
+		deletePayload, isDelete := payload.(*ike_message.Delete)
+		if !isDelete {
+			continue
+		}
+		handleInformationalDeletePayload(tngfSelf, ikeSecurityAssociation, deletePayload)
+	}
+}
+
+func handleInformationalDeletePayload(
+	tngfSelf *context.TNGFContext,
+	ikeSecurityAssociation *context.IKESecurityAssociation,
+	deletePayload *ike_message.Delete,
+) {
+	switch deletePayload.ProtocolID {
+	case ike_message.TypeESP:
+		if deletePayload.SPISize != 4 {
+			return
+		}
+
+		for i := uint16(0); i < deletePayload.NumberOfSPI; i++ {
+			offset := int(i) * 4
+			if offset+4 > len(deletePayload.SPIs) {
+				break
+			}
+
+			spi := binary.BigEndian.Uint32(deletePayload.SPIs[offset : offset+4])
+			tngfSelf.ChildSA.Delete(spi)
+			if ikeSecurityAssociation.ThisUE != nil {
+				delete(ikeSecurityAssociation.ThisUE.TNGFChildSecurityAssociation, spi)
+			}
+		}
+	case ike_message.TypeIKE:
+		tngfSelf.DeleteIKESecurityAssociation(ikeSecurityAssociation.LocalSPI)
 	}
 }
 

--- a/pkg/ike/handler/handler.go
+++ b/pkg/ike/handler/handler.go
@@ -660,7 +660,6 @@ func HandleIKEAUTH(udpConn *net.UDPConn, tngfAddr, ueAddr *net.UDPAddr, message 
 	// Load needed information
 	thisUE := tngfSelf.UELoadbyIDi(initiatorID.IDData)
 	fmt.Println("initiatorID.IDData: ", string(initiatorID.IDData))
-	ikeSecurityAssociation.ThisUE = thisUE
 	if thisUE == nil {
 		ikeLog.Errorln("UE is nil")
 		return
@@ -905,6 +904,7 @@ func HandleIKEAUTH(udpConn *net.UDPConn, tngfAddr, ueAddr *net.UDPAddr, message 
 
 	// Store SA into tngfUE
 	thisUE.TNGFIKESecurityAssociation = ikeSecurityAssociation
+	ikeSecurityAssociation.ThisUE.Store(thisUE)
 
 	// Store IKE Connection
 	UDPSocket := context.UDPSocketInfo{
@@ -1118,7 +1118,7 @@ func HandleCREATECHILDSA(udpConn *net.UDPConn, tngfAddr, ueAddr *net.UDPAddr, me
 	ikeSecurityAssociation.ResponderMessageID = message.MessageID
 
 	// UE context
-	thisUE := ikeSecurityAssociation.ThisUE
+	thisUE := ikeSecurityAssociation.ThisUE.Load()
 	if thisUE == nil {
 		ikeLog.Error("UE context is nil")
 		return
@@ -1424,6 +1424,22 @@ func HandleInformational(udpConn *net.UDPConn, tngfAddr, ueAddr *net.UDPAddr, me
 		}
 		handleInformationalDeletePayload(tngfSelf, ikeSecurityAssociation, deletePayload)
 	}
+
+	// RFC 7296 §2.21: every INFORMATIONAL request must receive an empty INFORMATIONAL response
+	responseIKEMessage := new(ike_message.IKEMessage)
+	var responseIKEPayload ike_message.IKEPayloadContainer
+	responseIKEMessage.BuildIKEHeader(
+		ikeSecurityAssociation.RemoteSPI,
+		ikeSecurityAssociation.LocalSPI,
+		ike_message.INFORMATIONAL,
+		ike_message.ResponseBitCheck,
+		message.MessageID,
+	)
+	if err := EncryptProcedure(ikeSecurityAssociation, responseIKEPayload, responseIKEMessage); err != nil {
+		ikeLog.Errorf("Encrypting INFORMATIONAL response failed: %+v", err)
+		return
+	}
+	SendIKEMessageToUE(udpConn, tngfAddr, ueAddr, responseIKEMessage)
 }
 
 func handleInformationalDeletePayload(
@@ -1445,12 +1461,18 @@ func handleInformationalDeletePayload(
 
 			spi := binary.BigEndian.Uint32(deletePayload.SPIs[offset : offset+4])
 			tngfSelf.ChildSA.Delete(spi)
-			if ikeSecurityAssociation.ThisUE != nil {
-				delete(ikeSecurityAssociation.ThisUE.TNGFChildSecurityAssociation, spi)
+			if ue := ikeSecurityAssociation.ThisUE.Load(); ue != nil {
+				ue.ChildSAMu.Lock()
+				delete(ue.TNGFChildSecurityAssociation, spi)
+				ue.ChildSAMu.Unlock()
 			}
 		}
 	case ike_message.TypeIKE:
-		tngfSelf.DeleteIKESecurityAssociation(ikeSecurityAssociation.LocalSPI)
+		if ue := ikeSecurityAssociation.ThisUE.Load(); ue != nil && ue.TNGFIKESecurityAssociation != nil {
+			ue.Remove()
+		} else {
+			tngfSelf.DeleteIKESecurityAssociation(ikeSecurityAssociation.LocalSPI)
+		}
 	}
 }
 


### PR DESCRIPTION
Closes https://github.com/free5gc/free5gc/issues/1000

Mitigates IKE SA accumulation with stale unauthenticated SA cleanup plus a max-SA cap.
Adds INFORMATIONAL DELETE cleanup for ESP child SA and IKE SA teardown paths.
Returns TEMPORARY_FAILURE on new SA allocation when capacity is exhausted