### PR TITLE
fix: handle missing Message-Authenticator in EAP-Message Access-Requests (#996)

### DIFF
--- a/pkg/radius/handler/handler.go
+++ b/pkg/radius/handler/handler.go
@@ -82,6 +82,11 @@ func HandleRadiusAccessRequest(udpConn *net.UDPConn, tngfAddr, ueAddr *net.UDPAd
 		}
 	}
 
+	if len(eapMessage) != 0 && requestMessageAuthenticator == nil {
+		radiusLog.Errorln("Access-Request with EAP-Message but no Message-Authenticator")
+		return
+	}
+
 	var session *context.RadiusSession
 	session, ok := tngfSelf.RadiusSessionPoolLoad(callingStationId)
 	if !ok {


### PR DESCRIPTION
Closes https://github.com/free5gc/free5gc/issues/996

Enforces RFC3579 behavior: drop Access-Request with EAP-Message when Message-Authenticator is missing.
Adds early validation in RADIUS handler to prevent unauthenticated EAP processing.