### PR TITLE
fix: prevent slice-bounds panic on malformed IKE SA proposal

### DIFF
--- a/pkg/ike/message/message.go
+++ b/pkg/ike/message/message.go
@@ -373,15 +373,23 @@ func (securityAssociation *SecurityAssociation) unmarshal(rawData []byte) error 
 		proposal.ProtocolID = rawData[5]
 
 		spiSize := rawData[6]
+		// spiSize is a uint8, so 8+spiSize overflows for spiSize >= 248; promote to int
+		// once and use it for every subsequent bound/slice to avoid a wrapped index.
+		spiEnd := 8 + int(spiSize)
 		if spiSize > 0 {
 			// bounds checking
-			if len(rawData) < int(8+spiSize) {
+			if len(rawData) < spiEnd {
 				return errors.New("Proposal: No sufficient bytes for unmarshalling SPI of proposal")
 			}
-			proposal.SPI = append(proposal.SPI, rawData[8:8+spiSize]...)
+			proposal.SPI = append(proposal.SPI, rawData[8:spiEnd]...)
 		}
 
-		transformData = rawData[8+spiSize : proposalLength]
+		// bounds checking
+		if spiEnd > int(proposalLength) {
+			return fmt.Errorf("Proposal: SPI size %d exceeds proposal length %d", spiSize, proposalLength)
+		}
+
+		transformData = rawData[spiEnd:proposalLength]
 
 		for len(transformData) > 0 {
 			// bounds checking

--- a/pkg/ike/message/message_test.go
+++ b/pkg/ike/message/message_test.go
@@ -442,3 +442,56 @@ func TestEncodeDecodeUsingPublicData(t *testing.T) {
 		t.FailNow()
 	}
 }
+
+// TestSecurityAssociationUnmarshalMalformedSPI verifies that a Security
+// Association payload whose SPI region does not fit inside the declared
+// proposal length is rejected with an error instead of panicking on an
+// out-of-bounds slice.
+func TestSecurityAssociationUnmarshalMalformedSPI(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload []byte
+	}{
+		{
+			// payload len=22; proposalLength=8 but spiSize=10 -> rawData[18:8] panics pre-fix
+			name: "spi size exceeds proposal length",
+			payload: []byte{
+				0x00, 0x00, 0x00, 0x16,
+				0x00, 0x00, 0x00, 0x08,
+				0x01, 0x01, 0x0a, 0x00,
+				0x00, 0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00, 0x00, 0x00, 0x00,
+			},
+		},
+		{
+			// payload len=13; proposalLength=8, spiSize=1 -> rawData[9:8] panics pre-fix
+			name: "minimal spi overflow",
+			payload: []byte{
+				0x00, 0x00, 0x00, 0x0d,
+				0x00, 0x00, 0x00, 0x08,
+				0x01, 0x01, 0x01, 0x00,
+				0x00,
+			},
+		},
+		{
+			// payload len=13; proposalLength=8, spiSize=0xf8 (248). uint8(8+248)=0,
+			// so a naive guard/slice computes rawData[8:0] and panics. This is the
+			// byte-overflow boundary (248-255) a plain int guard on the SPI-size check misses.
+			name: "spi size byte overflow",
+			payload: []byte{
+				0x00, 0x00, 0x00, 0x0d,
+				0x00, 0x00, 0x00, 0x08,
+				0x01, 0x01, 0xf8, 0x00,
+				0x00,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var container message.IKEPayloadContainer
+			if err := container.Decode(message.TypeSA, tt.payload); err == nil {
+				t.Fatalf("expected error for malformed SA payload, got nil")
+			}
+		})
+	}
+}


### PR DESCRIPTION
SecurityAssociation.unmarshal validated that the SPI region and the transform region fit within the received bytes, but computed the SPI end offset as 8+spiSize in uint8 arithmetic. Since spiSize is a uint8, that expression overflows for spiSize >= 248 (e.g. 8+248 wraps to 0), so the length guard passed and rawData[8:8+spiSize] sliced with a wrapped high bound (rawData[8:0]), panicking. A single crafted IKE_SA_INIT SA payload therefore crashes the TNGF process before authentication (the ike dispatcher's recover handler escalates the panic via Fatalf -> os.Exit).

Promote spiSize to int once (spiEnd) and use it for the SPI length check, the SPI slice, and the transform slice so none of the three can wrap. Valid packets (small SPI sizes) are unaffected; only inputs that previously panicked are now rejected with a decode error.

Add table-driven regression cases covering SPI sizes 1, 10, and the 248 byte-overflow boundary.

Fixes the TNGF portion of free5gc/free5gc#1073.